### PR TITLE
keepalive: replace explicit event handlers with property binding (#90)

### DIFF
--- a/qml/platform.qtcontrols/ApplicationWindowPL.qml
+++ b/qml/platform.qtcontrols/ApplicationWindowPL.qml
@@ -34,9 +34,7 @@ ApplicationWindow {
     property int   screenHeight: height
     property bool  screenLarge: true
     property int   screenWidth: width
-
-    // Emitted when keep alive requirements could have changed
-    signal checkKeepAlive
+    property bool  keepAlive: false // not used - desktop is not expected to be falling asleep
 
     StackView {
         id: pageStack
@@ -48,10 +46,6 @@ ApplicationWindow {
 
     function initPages() {
         pages.ps = pageStack;
-    }
-
-    function keepAlive(alive) {
-        // blank - desktop is not expected to be falling asleep
     }
 
     function updateOrientation() {

--- a/qml/platform.silica/ApplicationWindowPL.qml
+++ b/qml/platform.silica/ApplicationWindowPL.qml
@@ -34,7 +34,9 @@ ApplicationWindow {
     property string title
     property bool   keepAlive: false
 
-    DisplayBlanking.preventBlanking: applicationActive && keepAlive
+    DisplayBlanking {
+        preventBlanking: applicationActive && keepAlive
+    }
 
     Component.onCompleted: updateOrientation()
 

--- a/qml/platform.silica/ApplicationWindowPL.qml
+++ b/qml/platform.silica/ApplicationWindowPL.qml
@@ -34,11 +34,10 @@ ApplicationWindow {
     property string title
     property bool   keepAlive: false
 
-    KeepAlive {
-        enabled: applicationActive && keepAlive
+    Component.onCompleted: {
+        updateOrientation()
+        DisplayBlanking.preventBlanking = Qt.binding(function() { return applicationActive && keepAlive })
     }
-
-    Component.onCompleted: updateOrientation()
 
     Keys.onPressed: {
         // Allow zooming with plus and minus keys on the emulator.

--- a/qml/platform.silica/ApplicationWindowPL.qml
+++ b/qml/platform.silica/ApplicationWindowPL.qml
@@ -32,9 +32,9 @@ ApplicationWindow {
     property bool   screenLarge: Screen.sizeCategory >= Screen.Large
     property int    screenWidth: Screen.width
     property string title
+    property bool   keepAlive: false
 
-    // Emitted when keep alive requirements could have changed
-    signal checkKeepAlive
+    DisplayBlanking.preventBlanking: applicationActive && keepAlive
 
     Component.onCompleted: updateOrientation()
 
@@ -44,16 +44,10 @@ ApplicationWindow {
         (event.key === Qt.Key_Minus) && map.setZoomLevel(map.zoomLevel-1);
     }
 
-    onApplicationActiveChanged: checkKeepAlive()
-
     onDeviceOrientationChanged: updateOrientation()
 
     function initPages() {
         pages.ps = pageStack;
-    }
-
-    function keepAlive(alive) {
-        DisplayBlanking.preventBlanking = app.applicationActive && alive;
     }
 
     function updateOrientation() {

--- a/qml/platform.silica/ApplicationWindowPL.qml
+++ b/qml/platform.silica/ApplicationWindowPL.qml
@@ -34,8 +34,8 @@ ApplicationWindow {
     property string title
     property bool   keepAlive: false
 
-    DisplayBlanking {
-        preventBlanking: applicationActive && keepAlive
+    KeepAlive {
+        enabled: applicationActive && keepAlive
     }
 
     Component.onCompleted: updateOrientation()

--- a/qml/pure-maps.qml
+++ b/qml/pure-maps.qml
@@ -27,6 +27,9 @@ ApplicationWindowPL {
     pages: StackPL { }
     title: app.tr("Pure Maps")
 
+    keepAlive: app.conf.keepAlive === "always"
+               || (app.conf.keepAlive === "navigating" && (app.mode === modes.navigate || app.mode === modes.followMe))
+
     property var    conf: Config {}
     property bool   hasMapMatching: false
     property bool   initialized: false
@@ -78,7 +81,6 @@ ApplicationWindowPL {
 
     Connections {
         target: app.conf
-        onKeepAliveChanged: app.updateKeepAlive()
         onMapMatchingWhenNavigatingChanged: app.updateMapMatching()
         onMapMatchingWhenFollowingChanged: app.updateMapMatching()
         onMapMatchingWhenIdleChanged: app.updateMapMatching()
@@ -93,11 +95,6 @@ ApplicationWindowPL {
         app.conf.set("center", [app.map.center.longitude, app.map.center.latitude]);
         app.conf.set("zoom", app.map.zoomLevel);
         py.call_sync("poor.app.quit", []);
-    }
-
-    onCheckKeepAlive: {
-        if (!initialized) return;
-        app.updateKeepAlive();
     }
 
     onHasMapMatchingChanged: updateMapMatching()
@@ -116,7 +113,6 @@ ApplicationWindowPL {
             app.rerouteTotalCalls = 0;
             app.resetMenu();
         }
-        app.updateKeepAlive();
         app.updateMapMatching();
     }
 
@@ -150,7 +146,6 @@ ApplicationWindowPL {
     function initialize() {
         styler.initStyle();
         app.hasMapMatching = py.call_sync("poor.app.has_mapmatching", []);
-        updateKeepAlive();
         initialized = true;
     }
 
@@ -296,12 +291,6 @@ ApplicationWindowPL {
         for (var i = 1; i < arguments.length; i++)
             message = message.arg(arguments[i]);
         return message;
-    }
-
-    function updateKeepAlive() {
-        // Update state of keep-alive, i.e. display blanking prevention.
-        var alive = app.conf.keepAlive;
-        app.keepAlive(alive === "always" || (alive === "navigating" && (app.mode === modes.navigate || app.mode === modes.followMe)));
     }
 
     function updateMapMatching() {


### PR DESCRIPTION
PR showing what I meant in issue #90.

I wasn't yet able to test it myself because of the api keys and the handcrafted Makefile, so yeah, it's as-is :)

Basically, the platform AppWindows now have a keepAlive property that is bound there to a platform implementation of keeping alive the app, and in the pure-maps.qml that AppWindow property is bound to the conditions pure-maps wants (from the settings & application mode)