### PR TITLE
Add platform and SDK download instructions to flatpak docs

### DIFF
--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -5,7 +5,15 @@ making a copy of `tools/apikeys_dummy.py` and filling in the keys.
 If you wish to use Pure Maps without API keys, you could just avoid
 filling the keys.
 
-For building flatpak package, run
+For building the Pure Maps flatpak package first make sure you have the [Flathub repository installed](https://flatpak.org/setup/).
+
+Then install the runtime and SDK required to build the Pure Maps flatpak from the repository:
+
+```
+flatpak install flathub org.kde.Platform/x86_64/5.11 org.kde.Sdk/x86_64/5.11
+```
+
+Then finally run the Pure Maps flatpak build:
 
 ```
 flatpak-builder --repo=../flatpak --force-clean ../build-dir packaging/flatpak/io.github.rinigus.PureMaps.json


### PR DESCRIPTION
Looks like flatpak-builder does not download the platform and SDK
automatically, so it seems like a good idea to include instructions
how to install the Flathub repo & how to install the required platform
and SDK in the Pure Maps flatpak building docs.