### PR TITLE
Linux exe: replace Bash shebang for POSIX sh

### DIFF
--- a/data/pure-maps
+++ b/data/pure-maps
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # This script tries to send command to running Pure Maps
 # and starts new instance if it fails


### PR DESCRIPTION
Bash isn't actually required to run the script, any POSIX compatible shell will do.