### PR TITLE
Add an online map from OpenTopoMap.org

### DIFF
--- a/maps/opentopomap.json
+++ b/maps/opentopomap.json
@@ -1,0 +1,12 @@
+{
+  "attribution": {
+    "© OpenTopoMap": "https://opentopomap.org/",
+    "© SRTM": "http://viewfinderpanoramas.org/",
+    "© OpenStreetMap": "https://www.openstreetmap.org/copyright"
+  },
+  "format": "raster",
+  "name": "OpenTopoMap",
+  "profiles": ["mixed", "online"],
+  "tile_size": 256,
+  "tile_url": "https://a.tile.opentopomap.org/{z}/{x}/{y}.png"
+}


### PR DESCRIPTION
I like this one because its rendering is most similar to how the [most popular Czech topo maps issued by KČT](https://kct.cz/mapy-kct) look like. It also includes contour lines.

The only downside is that the online web app gets the path data from Longvia, and I have no clue how to add this overlay to Pure Maps.

I also don't know whether the Scout server supports multi-hostname URLs (`a.tiles.`.., `b.tiles.`..., etc).