### PR TITLE
Implemented a cross Platform Solution for DBus activation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ EXEDIR     = $(DESTDIR)$(PREFIX)/bin
 EXE        = $(EXEDIR)/$(NAME)
 DATADIR    = $(DESTDIR)$(PREFIX)/share/$(FULLNAME)
 DESKTOPDIR = $(DESTDIR)$(PREFIX)/share/applications
+DBUSDIR    = $(DESTDIR)$(PREFIX)/share/dbus-1/services
 ICONDIR    = $(DESTDIR)$(PREFIX)/share/icons/hicolor
 METADIR    = $(DESTDIR)$(PREFIX)/share/metainfo
 LANGS      = $(basename $(notdir $(wildcard po/*.po)))
@@ -161,7 +162,10 @@ endif
 	$(foreach lang,$(LANGS),$(call install-translation,$(lang)))
 	@echo "Installing desktop file..."
 	mkdir -p $(DESKTOPDIR)
-	cp data/$(NAME).desktop $(DESKTOPDIR) || cp data/pure-maps.desktop $(DESKTOPDIR)/$(NAME).desktop || true
+	cp data/$(NAME).desktop $(DESKTOPDIR) || cp data/io.github.rinigus.PureMaps.desktop $(DESKTOPDIR)/io.github.rinigus.PureMaps.desktop || true
+	@echo "Installing dbus service file..."
+	mkdir -p $(DBUSDIR)
+	cp data/io.github.rinigus.PureMaps.service $(DBUSDIR) || true
 	@echo "Installing executable file..."
 	mkdir -p $(EXEDIR)
 	cp data/$(NAME) $(EXE) || cp data/pure-maps $(EXE) || true

--- a/data/harbour-pure-maps
+++ b/data/harbour-pure-maps
@@ -1,26 +1,2 @@
 #!/bin/bash
-
-# This script tries to send command to running Pure Maps
-# and starts new instance if it fails
-
-set -e
-
-# compose dbus-send command
-options=""
-for i in $@; do
-    if [ ! -z "$options" ]; then
-        options="$options,"
-    fi
-    # have to escape commas due to https://gitlab.freedesktop.org/dbus/dbus/issues/76
-    options=$options'"'${i//,/.COMMA.}'"'
-done
-
-export QT_QUICK_CONTROLS_STYLE="${QT_QUICK_CONTROLS_STYLE:-org.kde.desktop}"
-dbus-send --session \
-          --dest=io.github.rinigus.PureMaps \
-          --type=method_call \
-          --print-reply \
-          /io/github/rinigus/PureMaps \
-          io.github.rinigus.PureMaps.command \
-          array:string:$options > /dev/null 2>&1 || \
-    exec sailfish-qml harbour-pure-maps -- "$@"
+exec sailfish-qml harbour-pure-maps -- $@

--- a/data/harbour-pure-maps-open-uri.desktop
+++ b/data/harbour-pure-maps-open-uri.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Pure Maps Uri Handler
+MimeType=x-scheme-handler/geo
+X-Maemo-Service=io.github.rinigus.PureMaps
+X-Maemo-Object-Path=/io/github/rinigus/PureMaps
+X-Maemo-Method=io.github.rinigus.PureMaps.Command
+Icon=harbour-pure-maps
+Type=Application
+NoDisplay=true

--- a/data/harbour-pure-maps.desktop
+++ b/data/harbour-pure-maps.desktop
@@ -1,7 +1,5 @@
 [Desktop Entry]
 Name=Pure Maps
-Exec=harbour-pure-maps %u
+Exec=sailfish-qml harbour-pure-maps
 Icon=harbour-pure-maps
 Type=Application
-MimeType=x-scheme-handler/geo
-# X-Nemo-Single-Instance=no

--- a/data/io.github.rinigus.PureMaps-silica.service
+++ b/data/io.github.rinigus.PureMaps-silica.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=io.github.rinigus.PureMaps
+Exec=/usr/bin/harbour-pure-maps

--- a/data/io.github.rinigus.PureMaps.desktop
+++ b/data/io.github.rinigus.PureMaps.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Pure Maps
+Exec=pure-maps
+Icon=pure-maps
+Type=Application
+MimeType=x-scheme-handler/geo
+DBusActivatable=true

--- a/data/io.github.rinigus.PureMaps.service
+++ b/data/io.github.rinigus.PureMaps.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=io.github.rinigus.PureMaps
+Exec=/usr/bin/pure-maps

--- a/data/pure-maps
+++ b/data/pure-maps
@@ -1,26 +1,2 @@
 #!/bin/bash
-
-# This script tries to send command to running Pure Maps
-# and starts new instance if it fails
-
-set -e
-
-# compose dbus-send command
-options=""
-for i in $@; do
-    if [ ! -z "$options" ]; then
-        options="$options,"
-    fi
-    # have to escape commas due to https://gitlab.freedesktop.org/dbus/dbus/issues/76
-    options=$options'"'${i//,/.COMMA.}'"'
-done
-
-#export QT_QUICK_CONTROLS_STYLE="${QT_QUICK_CONTROLS_STYLE:-org.kde.desktop}"
-dbus-send --session \
-          --dest=io.github.rinigus.PureMaps \
-          --type=method_call \
-          --print-reply \
-          /io/github/rinigus/PureMaps \
-          io.github.rinigus.PureMaps.command \
-          array:string:$options > /dev/null 2>&1 || \
-    exec qmlrunner -P INSTALL_PREFIX/share FULL_NAME -- "$@"
+exec qmlrunner -P INSTALL_PREFIX/share FULL_NAME -- $@

--- a/qml/Commander.qml
+++ b/qml/Commander.qml
@@ -31,34 +31,48 @@ Item {
         path: '/io/github/rinigus/PureMaps'
         service: 'io.github.rinigus.PureMaps'
 
-        xml: '  <interface name="io.github.rinigus.PureMaps">\n' +
-             '    <method name="command">\n' +
-             '       <arg name="options" direction="in" type="as"/>' +
-             '       <arg name="result" direction="out" type="s"/>' +
-             '    </method>\n' +
-             '    <method name="showPoi">\n' +
-             '       <arg name="latitude" direction="in" type="d"/>' +
-             '       <arg name="longitude" direction="in" type="d"/>' +
-             '       <arg name="result" direction="out" type="s"/>' +
-             '    </method>\n' +
-             '  </interface>\n'
+        xml: "<interface name='io.github.rinigus.PureMaps'>
+             <method name='Activate'>
+               <arg type='a{sv}' name='platform_data' direction='in'/>
+             </method>
+             <method name='Open'>
+               <arg type='as' name='uris' direction='in'/>
+             </method>
+             <method name='Command'>
+               <arg type='as' name='uris' direction='in'/>
+             </method>
+             <method name='ActivateAction'>
+               <arg type='s' name='action_name' direction='in'/>
+               <arg type='av' name='parameter' direction='in'/>
+               <arg type='a{sv}' name='platform_data' direction='in'/>
+             </method>
+           </interface>"
 
-        function command(options) {
-            var escaped = options.map(function(s) {
-                return s.replace(".COMMA.", ",")
-            })
-            commander.parser(escaped);
+        function rcActivate( platform_data ) {
             app.activate();
-            return "OK";
+            console.log( "DBUS METHOD CALLED: Activate" )
+            console.log( JSON.stringify(platform_data) )
         }
+        function rcOpen( uris, platform_data ) {
+            app.activate();
+            console.log( "DBUS METHOD CALLED: Open" )
+            console.log( JSON.stringify(uris) )
+            console.log( JSON.stringify(platform_data) )
+            parser( uris )
 
-        function showPoi(latitude, longitude) {
-            if (isFinite(latitude) && isFinite(longitude)) {
-                commander.showPoi(QtPositioning.coordinate(latitude, longitude));
-                app.activate();
-                return "OK";
-            }
-            return "Error: Coordinates are not numbers";
+        }
+        function rcActivateAction(action_name, parameter, platform_data ) {
+            app.activate();
+            console.log("DBUS METHOD CALLED: ActivateAction")
+            console.log( JSON.stringify(action_name) )
+            console.log( JSON.stringify(parameter) )
+            console.log( JSON.stringify(platform_data) )
+        }
+        function rcCommand( uris ) {
+            app.activate();
+            console.log( "DBUS METHOD CALLED: Command" )
+            console.log( JSON.stringify(uris) )
+            parser( uris )
         }
     }
 

--- a/rpm/harbour-pure-maps.spec
+++ b/rpm/harbour-pure-maps.spec
@@ -32,11 +32,17 @@ search for nearby places by type and share your location.
 
 %install
 make DESTDIR=%{buildroot} PREFIX=/usr INCLUDE_GPXPY=yes install
+# Not needed for non silica
+cp data/harbour-pure-maps-open-uri.desktop %{buildroot}%{_datadir}/applications/%{name}-open-uri.desktop
+# Overwrites the non silica one
+cp data/io.github.rinigus.PureMaps-silica.service %{buildroot}%{_datadir}/dbus-1/services/io.github.rinigus.PureMaps.service
 
 %files
 %defattr(-,root,root,-)
 %{_bindir}
 %{_datadir}/%{name}
 %{_datadir}/applications/%{name}.desktop
+%{_datadir}/applications/%{name}-open-uri.desktop
+%{_datadir}/dbus-1/services/io.github.rinigus.PureMaps.service
 %{_datadir}/icons/hicolor/*/apps/%{name}.png
 %exclude /usr/share/metainfo/harbour-pure-maps.appdata.xml


### PR DESCRIPTION
Hi,
To improve on the current solution for #82 this (should) enable the standard DBus activation on non silica Platforms. Since SFOS didn't seem to support this, the same method as the sailfish-browser is used on silica.
In order to achieve this, first a .service file is added for dbus (in .spec and Makefile), the DBus Activation interface with an additional command method Implemented (in Commander.qml) and some lines in the desktop files added. The -open-uri one with 'X-Maemo-' are for silica and the renaming to the reverse DNS scheme and 'DbusActivatable=true' for the other ones.

PS: I Dropped the '%u' in the desktop files Exec line, but they should be kept to enable 'classic' command line support