### PR TITLE
Package Flite with Ubuntu Touch click

### DIFF
--- a/packaging/ubports/clickable.json
+++ b/packaging/ubports/clickable.json
@@ -31,6 +31,14 @@
     "nemo-qml-plugin-dbus": {
       "build_dir": "build_ubports/$ARCH_TRIPLET/$NAME",
       "template": "qmake"
+    },
+    "flite": {
+      "build_dir": "build_ubports/$ARCH_TRIPLET/$NAME",
+      "template": "custom",
+      "build": "cp -r $SRC_DIR $BUILD_DIR/$NAME && cd $BUILD_DIR/$NAME && ./configure --prefix=\"$INSTALL_DIR\" --exec-prefix=\"$INSTALL_DIR\" --host=$ARCH_TRIPLET && make && make get_voices && make install",
+      "dependencies_target": [
+        "libtool"
+      ]
     }
   }
 }

--- a/packaging/ubports/install-deps.sh
+++ b/packaging/ubports/install-deps.sh
@@ -22,6 +22,12 @@ mkdir -p $BIN_INSTALL_DIR
 
 mv $GENERAL_BUILD_DIR/pure-maps/click/bin/* $BIN_INSTALL_DIR
 cp $GENERAL_BUILD_DIR/qmlrunner/qmlrunner $BIN_INSTALL_DIR
+cp $GENERAL_BUILD_DIR/flite/install/bin/flite{,_cmu_us_kal16,_cmu_us_slt} $BIN_INSTALL_DIR
+
+# Strip binaries
+if [ "$ARCH_TRIPLET" == "arm-linux-gnueabihf" ]; then
+	arm-linux-gnueabihf-strip -s $BIN_INSTALL_DIR/flite*
+fi
 
 # Install libs
 mkdir -p $LIBS_INSTALL_DIR

--- a/packaging/ubports/prepare-deps.sh
+++ b/packaging/ubports/prepare-deps.sh
@@ -8,15 +8,17 @@ MAPBOX_GL_NATIVE_SRC_DIR=$ROOT_DIR/libs/mapbox-gl-native
 MAPBOX_GL_QML_SRC_DIR=$ROOT_DIR/libs/mapbox-gl-qml
 NEMO_QML_PLUGIN_DBUS_SRC_DIR=$ROOT_DIR/libs/nemo-qml-plugin-dbus
 QMLRUNNER_SRC_DIR=$ROOT_DIR/libs/qmlrunner
+FLITE_SRC_DIR=$ROOT_DIR/libs/flite
 
 # Remove old downloads
-rm -rf $MAPBOX_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $NEMO_QML_PLUGIN_DBUS_SRC_DIR $QMLRUNNER_SRC_DIR
+rm -rf $MAPBOX_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $NEMO_QML_PLUGIN_DBUS_SRC_DIR $QMLRUNNER_SRC_DIR $FLITE_SRC_DIR
 
 # Download sources
 git clone -b qt-regular https://github.com/rinigus/pkg-mapbox-gl-native.git $MAPBOX_GL_NATIVE_SRC_DIR --recurse-submodules  --shallow-submodules
 git clone https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
 git clone https://git.merproject.org/mer-core/nemo-qml-plugin-dbus.git $NEMO_QML_PLUGIN_DBUS_SRC_DIR 
 git clone https://github.com/rinigus/qmlrunner.git $QMLRUNNER_SRC_DIR
+git clone https://github.com/festvox/flite --depth 1 $FLITE_SRC_DIR
 
 # Replace mapbox-gl-native pro file
 rm $MAPBOX_GL_NATIVE_SRC_DIR/mapbox-gl-native/mapbox-gl-native.pro


### PR DESCRIPTION
This builds and ships flite with the Ubuntu Touch package.

# Issues
- Click package with Flite is 23 MB in size