### PR TITLE
[ubports] uses suru system theme

### DIFF
--- a/data/pure-maps
+++ b/data/pure-maps
@@ -23,4 +23,4 @@ dbus-send --session \
           /io/github/rinigus/PureMaps \
           io.github.rinigus.PureMaps.command \
           array:string:$options > /dev/null 2>&1 || \
-    exec qmlrunner -P INSTALL_PREFIX/share FULL_NAME -- "$@"
+    export QT_QUICK_CONTROLS_STYLE=suru && exec qmlrunner -P INSTALL_PREFIX/share FULL_NAME -- "$@"


### PR DESCRIPTION
Hi, I'm not sure if this conflict with anything else - Jonnius instructed to aim patches towards your base.

This is a change that exports an environment variable so that ubports version of the app pick up on the system theme, this fixes many drop-down box styles/scaling the background respects the system theme