### PR TITLE
[ubports] fixes bug with having to hit space twice

### DIFF
--- a/qml/platform.qtcontrols/SearchFieldPL.qml
+++ b/qml/platform.qtcontrols/SearchFieldPL.qml
@@ -26,6 +26,7 @@ TextField {
     anchors.leftMargin: styler.themeHorizontalPageMargin
     anchors.right: parent.right
     anchors.rightMargin: styler.themeHorizontalPageMargin
+    inputMethodHints: Qt.ImhNoPredictiveText
     focus: true
     leftPadding: searchButton.width + searchButton.anchors.leftMargin + styler.themePaddingMedium
     rightPadding: clearButton.width + clearButton.anchors.leftMargin + styler.themePaddingMedium


### PR DESCRIPTION

This is a change that fixes an issue where the system spellchecking/auto suggest is conflicting with ontextchanged - resulting in the user having to press the spacebar twice to enter a space. Since the search auto suggest is suggesting results, and most street names/numbers arern't as beneficial to autocorrect ( may correct to wrong) disabling predictivetext may be good here.

The alternative may be to use ontextcompleted (i think is what was called), but that would delay suggestions until return was hit. 