### PR TITLE
Fix policies and Maintainer name

### DIFF
--- a/packaging/ubports/clickable.json
+++ b/packaging/ubports/clickable.json
@@ -2,7 +2,7 @@
   "clickable_minimum_required": "5.14.1",
   "template": "custom",
   "kill": "pure-maps",
-  "build": "cd $ROOT && make platform-ubports && make FULLNAME=pure-maps.jonius PREFIX=. DESTDIR=$INSTALL_DIR/ INCLUDE_GPXPY=yes QT_PLATFORM_STYLE=suru TMP_AS_CACHE=yes install",
+  "build": "cd $ROOT && make platform-ubports && make FULLNAME=pure-maps.jonnius PREFIX=. DESTDIR=$INSTALL_DIR/ INCLUDE_GPXPY=yes QT_PLATFORM_STYLE=suru TMP_AS_CACHE=yes install",
   "prebuild": "cd $ROOT && tools/manage-keys inject .",
   "postbuild": "cd $ROOT && tools/manage-keys strip . && $ROOT/packaging/ubports/install-deps.sh $ARCH_TRIPLET",
   "build_dir": "build_ubports/$ARCH_TRIPLET/pure-maps",

--- a/packaging/ubports/manifest.json
+++ b/packaging/ubports/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "pure-maps.jonius",
+    "name": "pure-maps.jonnius",
     "description": "Maps and Navigation",
     "architecture": "armhf",
     "title": "Pure Maps",

--- a/packaging/ubports/pure-maps.apparmor
+++ b/packaging/ubports/pure-maps.apparmor
@@ -1,13 +1,9 @@
 {
     "policy_groups": [
-        "content_exchange",
-        "content_exchange_source",
         "audio",
-        "connectivity",
         "keep-display-on",
         "location",
-        "networking",
-        "sensors"
+        "networking"
     ],
     "policy_version": 16.04
 }


### PR DESCRIPTION
This PR 
- removes AppArmor permission we should not need
- fixes the Click package maintainer name :smile: 