### PR TITLE
Add Ubuntu Touch flag to desktop file

### DIFF
--- a/data/pure-maps.desktop
+++ b/data/pure-maps.desktop
@@ -4,4 +4,5 @@ Exec=pure-maps %u
 Icon=pure-maps
 Type=Application
 MimeType=x-scheme-handler/geo
+X-Ubuntu-Touch=true
 


### PR DESCRIPTION
This flag is needed to publish Pure Maps in the Open Store.