### PR TITLE
Multi arch support on Ubuntu Touch

### DIFF
--- a/packaging/ubports/README.md
+++ b/packaging/ubports/README.md
@@ -16,6 +16,10 @@ all clickable calls:
 Otherwise you'll have to append `-c packaging/ubports/clickable.json` to all
 clickable commands.
 
+If you did not clone this repository recursively, get the submodules:
+
+    git submodule update --init
+
 ## Dependencies
 
 **WARNING**: Dependencies may take hours to build (especially mimic).

--- a/packaging/ubports/clickable.json
+++ b/packaging/ubports/clickable.json
@@ -1,10 +1,10 @@
 {
-  "clickable_minimum_required": "6.0.2",
+  "clickable_minimum_required": "6.6",
   "template": "custom",
   "kill": "pure-maps",
-  "build": "cd $ROOT && make platform-ubports && make FULLNAME=pure-maps.jonnius PREFIX=. DESTDIR=$INSTALL_DIR/ INCLUDE_GPXPY=yes QT_PLATFORM_STYLE=suru TMP_AS_CACHE=yes install && cp $ROOT/packaging/ubports/pure-maps.desktop $INSTALL_DIR/share/applications",
+  "build": "cd $ROOT && make platform-ubports && make FULLNAME=pure-maps.jonnius PREFIX=. DESTDIR=$INSTALL_DIR/ INCLUDE_GPXPY=yes QT_PLATFORM_STYLE=suru TMP_AS_CACHE=yes install && cp $ROOT/packaging/ubports/pure-maps.desktop $INSTALL_DIR/share/applications && $ROOT/packaging/ubports/install-deps.sh $ARCH_TRIPLET",
   "prebuild": "cd $ROOT && tools/manage-keys inject .",
-  "postbuild": "cd $ROOT && tools/manage-keys strip . && $ROOT/packaging/ubports/install-deps.sh $ARCH_TRIPLET",
+  "postbuild": "cd $ROOT && tools/manage-keys strip .",
   "build_dir": "build_ubports/$ARCH_TRIPLET/pure-maps",
   "install_dir": "$BUILD_DIR/click",
   "scripts": {

--- a/packaging/ubports/manifest.json
+++ b/packaging/ubports/manifest.json
@@ -9,7 +9,7 @@
             "desktop":  "pure-maps.desktop"
         }
     },
-    "version": "1.26.1",
+    "version": "1.26.1.1",
     "maintainer": "Jonatan Hatakeyama Zeidler <jonatan_zeidler@gmx.de>",
     "framework" : "ubuntu-sdk-16.04"
 }

--- a/packaging/ubports/manifest.json
+++ b/packaging/ubports/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "pure-maps.jonnius",
     "description": "Maps and Navigation",
-    "architecture": "armhf",
+    "architecture": "@CLICK_ARCH@",
     "title": "Pure Maps",
     "hooks": {
         "pure-maps": {


### PR DESCRIPTION
Allow building arm64  and amd64 click packges besides armhf. Requires a [Clickable patch](https://gitlab.com/clickable/clickable/merge_requests/192).