### PR TITLE
Specify encoding on keys file

### DIFF
--- a/tools/manage-keys
+++ b/tools/manage-keys
@@ -30,7 +30,7 @@ else: print( 'Stripping keys from %s' % root)
 for dname in ['qml', 'geocoders', 'guides', 'maps', 'poor', 'routers']:
     for ext in ["py", "qml", "json"]:
         for fname in glob.glob(os.path.join(root, dname, "*." + ext)):
-            with open(fname, 'r') as f:
+            with open(fname, 'r', encoding='utf-8') as f:
                 s = f.read()
             keys = ""
             for k, v in Keys.items():


### PR DESCRIPTION
Without specifying encoding the script does not work in the Clickable docker containers. This change prevents the setup to break with an upcoming change in Clickable.