### PR TITLE
Clickable update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tools/apikeys.py
 /build/
 /qml/platform
 /.clickable/
+/clickable.json

--- a/packaging/ubports/README.md
+++ b/packaging/ubports/README.md
@@ -20,37 +20,12 @@ clickable commands.
 
 **WARNING**: Dependencies may take hours to build (especially mimic).
 
-Download dependency sources:
+Run the following command to download and compile the app dependencies:
 
     clickable prepare-deps
-
-### Python >= 3.6
-Run the following command to download and compile the app dependencies:
-
-    clickable build-libs --arch armhf # or arm64 depending on your device
-
-If you'd like to debug on desktop, too, also compile the dependencies for amd64:
-
-    clickable build-libs --arch amd64
-
-### Python < 3.6
-Run the following command to download and compile the app dependencies:
-
-    clickable build-libs mapbox-gl-native --arch armhf # or arm64
-    clickable build-libs mapbox-gl-qml --arch armhf # or arm64
-    clickable build-libs qmlrunner --arch armhf # or arm64
-    clickable build-libs nemo-qml-plugin-dbus --arch armhf # or arm64
-    clickable build-libs mimic --arch armhf # or arm64
-    clickable build-libs picotts --arch armhf # or arm64
-
-If you'd like to debug on desktop, too, also compile the dependencies for amd64:
-
-    clickable build-libs mapbox-gl-native --arch amd64
-    clickable build-libs mapbox-gl-qml --arch amd64
-    clickable build-libs qmlrunner --arch amd64
-    clickable build-libs nemo-qml-plugin-dbus --arch amd64
-    clickable build-libs mimic --arch amd64
-    clickable build-libs picotts --arch amd64
+    clickable build-libs --arch armhf # for armhf devices
+    clickable build-libs --arch arm64 # for arm64 devices
+    clickable build-libs --arch amd64 # for desktop mode
 
 ## Building
 

--- a/packaging/ubports/clickable.json
+++ b/packaging/ubports/clickable.json
@@ -1,6 +1,6 @@
 {
-  "clickable_minimum_required": "6.9.1",
-  "template": "custom",
+  "clickable_minimum_required": "6.13.0",
+  "builder": "custom",
   "kill": "pure-maps",
   "build": "cd ${ROOT} && make platform-ubports && make FULLNAME=pure-maps.jonnius PREFIX=. DESTDIR=${INSTALL_DIR}/ INCLUDE_GPXPY=yes QT_PLATFORM_STYLE=suru TMP_AS_CACHE=yes install",
   "prebuild": "cd ${ROOT} && tools/manage-keys inject .",
@@ -30,23 +30,23 @@
   "libraries": {
     "mapbox-gl-native": {
       "src_dir": "libs/mapbox-gl-native/mapbox-gl-native",
-      "template": "qmake"
+      "builder": "qmake"
     },
     "qmlrunner": {
-      "template": "qmake"
+      "builder": "qmake"
     },
     "mapbox-gl-qml": {
-      "template": "qmake",
+      "builder": "qmake",
       "build_args": [
         "INCLUDEPATH+=${BUILD_DIR}/../mapbox-gl-native/install/usr/include/${ARCH_TRIPLET}/qt5",
         "LIBS+=-L${BUILD_DIR}/../mapbox-gl-native/install/usr/lib/${ARCH_TRIPLET}"
       ]
     },
     "nemo-qml-plugin-dbus": {
-      "template": "qmake"
+      "builder": "qmake"
     },
     "mimic": {
-      "template": "custom",
+      "builder": "custom",
       "build": "cp -r ${SRC_DIR}/* ${BUILD_DIR} && ./autogen.sh && ./configure --with-audio=none --prefix=${INSTALL_DIR} --exec-prefix=${INSTALL_DIR} --host=${ARCH_TRIPLET} && make -j4 &&  make install",
       "dependencies_target": [
         "libtool",
@@ -55,7 +55,7 @@
       ]
     },
     "picotts": {
-      "template": "custom",
+      "builder": "custom",
       "build": "cp -r ${SRC_DIR}/* ${BUILD_DIR} && DESTDIR=${INSTALL_DIR} LANG_DIR=./usr/share/picotts/lang make -j4 && DESTDIR=${INSTALL_DIR} make install",
       "dependencies_target": [
         "libtool",


### PR DESCRIPTION
Update clickable.json to Clickable 6.13.0 and remove Python 2 instructions from UBports packaging README.