### PR TITLE
Ubports: Fix nemo qml plugin install path

### DIFF
--- a/packaging/ubports/clickable.json
+++ b/packaging/ubports/clickable.json
@@ -22,7 +22,7 @@
     "${MAPBOX_GL_NATIVE_LIB_INSTALL_DIR}/lib/*.so*",
     "${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/*",
     "${NEMO_QML_PLUGIN_DBUS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/*",
-    "${NEMO_QML_PLUGIN_DBUS_LIB_INSTALL_DIR}/usr/lib/*.so*"
+    "${NEMO_QML_PLUGIN_DBUS_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/*.so*"
   ],
   "scripts": {
     "prepare-deps": "git submodule update --recursive --init && ${ROOT}/packaging/ubports/prepare-deps.sh"


### PR DESCRIPTION
Just did a fresh build for the release and figured that some install path needed to be adjusted.