### PR TITLE
Change app name in desktop file for different UBports versions

### DIFF
--- a/packaging/ubports/full-build.json
+++ b/packaging/ubports/full-build.json
@@ -4,7 +4,7 @@
   "kill": "pure-maps",
   "build": "cd ${ROOT} && make platform-ubports && make FULLNAME=pure-maps.jonnius PREFIX=. DESTDIR=${INSTALL_DIR}/ INCLUDE_GPXPY=yes QT_PLATFORM_STYLE=suru TMP_AS_CACHE=yes install",
   "prebuild": "cd ${ROOT} && tools/manage-keys inject .",
-  "postbuild": "cd ${ROOT} && tools/manage-keys strip . && sed -i 's/@APP_TITLE@/Pure Maps/g' ${INSTALL_DIR}/manifest.json && sed -i 's/@APP_NAME@/pure-maps/g' ${INSTALL_DIR}/manifest.json",
+  "postbuild": "cd ${ROOT} && tools/manage-keys strip . && sed -i 's/@APP_TITLE@/Pure Maps/g' ${INSTALL_DIR}/manifest.json && sed -i 's/@APP_TITLE@/Pure Maps/g' ${INSTALL_DIR}/pure-maps.desktop && sed -i 's/@APP_NAME@/pure-maps/g' ${INSTALL_DIR}/manifest.json",
   "install_data": {
     "${ROOT}/packaging/ubports/pure-maps.desktop": "${INSTALL_DIR}",
     "${ROOT}/packaging/ubports/manifest.json": "${INSTALL_DIR}",

--- a/packaging/ubports/pure-maps.desktop
+++ b/packaging/ubports/pure-maps.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Pure Maps
+Name=@APP_TITLE@
 Exec=pure-maps %u
 Icon=pure-maps.svg
 Type=Application

--- a/packaging/ubports/slim-build.json
+++ b/packaging/ubports/slim-build.json
@@ -4,7 +4,7 @@
   "kill": "pure-maps",
   "build": "cd ${ROOT} && make platform-ubports && make FULLNAME=pure-maps-slim.jonnius PREFIX=. DESTDIR=${INSTALL_DIR}/ INCLUDE_GPXPY=yes QT_PLATFORM_STYLE=suru TMP_AS_CACHE=yes install",
   "prebuild": "cd ${ROOT} && tools/manage-keys inject .",
-  "postbuild": "cd ${ROOT} && tools/manage-keys strip . && sed -i 's/@APP_TITLE@/Pure Maps Slim/g' ${INSTALL_DIR}/manifest.json  && sed -i 's/@APP_NAME@/pure-maps-slim/g' ${INSTALL_DIR}/manifest.json",
+  "postbuild": "cd ${ROOT} && tools/manage-keys strip . && sed -i 's/@APP_TITLE@/Pure Maps Slim/g' ${INSTALL_DIR}/manifest.json && sed -i 's/@APP_TITLE@/Pure Maps Slim/g' ${INSTALL_DIR}/pure-maps.desktop && sed -i 's/@APP_NAME@/pure-maps-slim/g' ${INSTALL_DIR}/manifest.json",
   "install_data": {
     "${ROOT}/packaging/ubports/pure-maps.desktop": "${INSTALL_DIR}",
     "${ROOT}/packaging/ubports/manifest.json": "${INSTALL_DIR}",


### PR DESCRIPTION
This changes the name in Lomiris launcher according to the name of the app as displayed in the OpenStore.