### PR TITLE
Remove tmp in cache workaround for Ubuntu Touch

### DIFF
--- a/data/pure-maps
+++ b/data/pure-maps
@@ -15,12 +15,6 @@ for i in "$@"; do
     options=$options${i//,/.COMMA.}
 done
 
-# INSERT_TMP_AS_CACHE
-
-TMPINCACHEDIR="${XDG_CACHE_HOME:-$HOME/.cache}"/FULL_NAME/tmp
-if [ "$USE_CACHE_AS_TMP" = "yes" ]; then
-    TMPDIR=$TMPINCACHEDIR
-fi
 XDG_DATA_DIRS="${XDG_DATA_DIRS:-$HOME/.local/share}":INSTALL_PREFIX/share/FULL_NAME
 
 # INSERT_PLATFORM_STYLE

--- a/packaging/click/full-build.json
+++ b/packaging/click/full-build.json
@@ -9,7 +9,7 @@
     "S2INCLUDES=${S2GEOMETRY_LIB_INSTALL_DIR}/include",
     "S2LIBS=-L${S2GEOMETRY_LIB_INSTALL_DIR}/lib"
   ],
-  "postbuild": "sed -i 's/@APP_TITLE@/Pure Maps/g' ${INSTALL_DIR}/manifest.json && sed -i 's/@APP_TITLE@/Pure Maps/g' ${INSTALL_DIR}/pure-maps.desktop && sed -i 's/@APP_NAME@/pure-maps/g' ${CLICK_PATH}/launch.sh && sed -i 's/@APP_NAME@/pure-maps/g' ${INSTALL_DIR}/manifest.json && mv ${INSTALL_DIR}/bin/pure-maps.jonnius ${CLICK_PATH}/pure-maps",
+  "postbuild": "sed -i 's/@APP_TITLE@/Pure Maps/g' ${INSTALL_DIR}/manifest.json && sed -i 's/@APP_TITLE@/Pure Maps/g' ${INSTALL_DIR}/pure-maps.desktop && sed -i 's/@APP_NAME@/pure-maps/g' ${INSTALL_DIR}/manifest.json && mv ${INSTALL_DIR}/bin/pure-maps.jonnius ${CLICK_PATH}/pure-maps",
   "install_data": {
     "${ROOT}/packaging/click/pure-maps.desktop": "${INSTALL_DIR}",
     "${ROOT}/packaging/click/manifest.json": "${INSTALL_DIR}",
@@ -18,7 +18,6 @@
     "${PICOTTS_LIB_INSTALL_DIR}/usr/share/picotts": "${INSTALL_DIR}/usr/share"
   },
   "install_bin": [
-    "${SRC_DIR}/packaging/click/launch.sh",
     "${MIMIC_LIB_INSTALL_DIR}/bin/mimic",
     "${PICOTTS_LIB_INSTALL_DIR}/usr/bin/pico2wave"
   ],

--- a/packaging/click/launch.sh
+++ b/packaging/click/launch.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-set -Eeou pipefail
-
-TMPDIR=~/.cache/@APP_NAME@.jonnius/tmp pure-maps

--- a/packaging/click/pure-maps.desktop
+++ b/packaging/click/pure-maps.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=@APP_TITLE@
-Exec=launch.sh %u
+Exec=pure-maps %u
 Icon=pure-maps.svg
 Type=Application
 MimeType=x-scheme-handler/geo

--- a/packaging/click/slim-build.json
+++ b/packaging/click/slim-build.json
@@ -9,7 +9,7 @@
     "S2INCLUDES=${S2GEOMETRY_LIB_INSTALL_DIR}/include",
     "S2LIBS=-L${S2GEOMETRY_LIB_INSTALL_DIR}/lib"
   ],
-  "postbuild": "sed -i 's/@APP_TITLE@/Pure Maps Slim/g' ${INSTALL_DIR}/manifest.json && sed -i 's/@APP_TITLE@/Pure Maps Slim/g' ${INSTALL_DIR}/pure-maps.desktop && sed -i 's/@APP_NAME@/pure-maps-slim/g' ${CLICK_PATH}/launch.sh && sed -i 's/@APP_NAME@/pure-maps-slim/g' ${INSTALL_DIR}/manifest.json && mv ${INSTALL_DIR}/bin/pure-maps-slim.jonnius ${CLICK_PATH}/pure-maps",
+  "postbuild": "sed -i 's/@APP_TITLE@/Pure Maps Slim/g' ${INSTALL_DIR}/manifest.json && sed -i 's/@APP_TITLE@/Pure Maps Slim/g' ${INSTALL_DIR}/pure-maps.desktop && sed -i 's/@APP_NAME@/pure-maps-slim/g' ${INSTALL_DIR}/manifest.json && mv ${INSTALL_DIR}/bin/pure-maps-slim.jonnius ${CLICK_PATH}/pure-maps",
   "install_data": {
     "${ROOT}/packaging/click/pure-maps.desktop": "${INSTALL_DIR}",
     "${ROOT}/packaging/click/manifest.json": "${INSTALL_DIR}",
@@ -18,7 +18,6 @@
     "${PICOTTS_LIB_INSTALL_DIR}/usr/share/picotts": "${INSTALL_DIR}/usr/share"
   },
   "install_bin": [
-    "${SRC_DIR}/packaging/click/launch.sh",
     "${PICOTTS_LIB_INSTALL_DIR}/usr/bin/pico2wave"
   ],
   "install_lib": [


### PR DESCRIPTION
Fixes #467. This has been tested on the Ubuntu Touch dev channel.

Please wait with merging until [OTA 16](https://github.com/orgs/ubports/projects/25#card-50989623) is released to avoid breaking audio for our Ubuntu Touch users for the time being. I will send a ping here once ready.