### PR TITLE
Explicitly invoke python3 in check-json

### DIFF
--- a/tools/check-json
+++ b/tools/check-json
@@ -3,4 +3,4 @@
 set -e
 
 echo Checking "$1"
-python -m json.tool "$1" > /dev/null || (echo Check failed && exit 255)
+python3 -m json.tool "$1" > /dev/null || (echo Check failed && exit 255)


### PR DESCRIPTION
`python` refers to `python2` in some distributions which we don't want.