### PR TITLE
Let clickable set framework version in click package manifest

### DIFF
--- a/packaging/click/full-build.json
+++ b/packaging/click/full-build.json
@@ -1,5 +1,5 @@
 {
-  "clickable_minimum_required": "6.13.0",
+  "clickable_minimum_required": "6.23.3",
   "builder": "qmake",
   "kill": "pure-maps",
   "build_args": [

--- a/packaging/click/manifest.json
+++ b/packaging/click/manifest.json
@@ -11,5 +11,5 @@
     },
     "version": "2.6.0",
     "maintainer": "Rinigus <rinigus.git@gmail.org>",
-    "framework" : "ubuntu-sdk-16.04"
+    "framework" : "@CLICK_FRAMEWORK@"
 }

--- a/packaging/click/slim-build.json
+++ b/packaging/click/slim-build.json
@@ -1,5 +1,5 @@
 {
-  "clickable_minimum_required": "6.13.0",
+  "clickable_minimum_required": "6.23.3",
   "builder": "qmake",
   "kill": "pure-maps",
   "build_args": [


### PR DESCRIPTION
The click review tool got stricter on importing modules without specifying a framework that guarantees those. Let's let Clickable set the framework field automatically.