### PR TITLE
maps: add online map for openslopemap

### DIFF
--- a/maps/openslopemap.json
+++ b/maps/openslopemap.json
@@ -1,0 +1,10 @@
+{
+    "attribution": {
+        "© OpenSlopeMap": "https://openslopemap.org"
+    },
+    "format": "raster",
+    "name": "OpenSlopeMap",
+    "profiles": ["mixed", "online"],
+    "tile_size": 256,
+    "tile_url": "https://wmts.openslopemap.org/wmts/OSloMap_HR_AlpsEast_16/{z}/{x}/{y}.png"
+}


### PR DESCRIPTION
A map that is useful for skiing and other mountain activity to judge
avalanche risk.

Closes: #496
Signed-off-by: Henning Schild <henning@hennsch.de>