### PR TITLE
Replace GPL-3.0+ licence identifier with GPL-3.0-or-later

### DIFF
--- a/packaging/pure-maps.appdata.xml
+++ b/packaging/pure-maps.appdata.xml
@@ -21,7 +21,7 @@
  <provides>
   <binary>pure-maps</binary>
  </provides>
- <project_license>GPL-3.0+</project_license>
+ <project_license>GPL-3.0-or-later</project_license>
  <screenshots>
   <screenshot type="default">
    <caption>Main screen of the application</caption>


### PR DESCRIPTION
The GPL-3.0+ SPDX licence identifier has been deprecated in favour
of GPL-3.0-or-later, so let's replace it with that.

See:

 - https://spdx.org/licenses/GPL-3.0+
 - https://spdx.org/licenses/GPL-3.0-or-later