### PR TITLE
Adjust CMake for better Qt Creator support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,8 @@ project(pure-maps
     VERSION 2.6.5
     DESCRIPTION "Maps and navigation")
 
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
-include(FeatureSummary)
-include(GNUInstallDirs)
-include(CMakePrintHelpers)
-
+# options
+set(APP_NAME "" CACHE STRING "Name of the application, specify if custom name is needed")
 set(FLAVOR "kirigami" CACHE STRING "Platform to build support for. Supported platforms: kirigami, silica, qtcontrols, uuitk")
 set(PROFILE "Online" CACHE STRING "Default profile. Supported profiles: Online, Mixed, Offline")
 set(PYTHON_EXE "auto" CACHE STRING "Set python3 executable. If set to 'auto', cmake will try to find it.")
@@ -21,6 +14,7 @@ set(S2INCLUDES "" CACHE STRING "Custom installed location for s2geometry, includ
 set(S2LIBS "" CACHE STRING "Custom installed location for s2geometry, libs")
 option(USE_BUNDLED_GPXPY "Use a bundled version of GPXPY rather than a system-wide version" ON)
 
+# check options
 set(VALID_FLAVOR_OPTIONS
     "kirigami"
     "silica"
@@ -47,22 +41,37 @@ else()
     return()
 endif()
 
-if(FLAVOR STREQUAL "silica")
-    set(APP_NAME harbour-pure-maps)
-else()
-    set(APP_NAME pure-maps)
+# set app name
+if(NOT APP_NAME)
+    if(FLAVOR STREQUAL "silica")
+        set(APP_NAME harbour-pure-maps)
+    else()
+        set(APP_NAME pure-maps)
+    endif()
 endif()
 
+# requirements
 set(QT_MIN_VERSION "5.6.0")
-find_package(Gettext REQUIRED)
-find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS Gui Positioning Qml Quick DBus LinguistTools REQUIRED)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
 
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+include(FeatureSummary)
+include(GNUInstallDirs)
+include(CMakePrintHelpers)
+
+find_package(Gettext REQUIRED)
+
+# allow to compile on platforms without FindPython3.cmake
 if(PYTHON_EXE STREQUAL "auto")
     find_package(Python3 COMPONENTS Interpreter REQUIRED)
 else()
     set(PYTHON_EXECUTABLE ${PYTHON_EXE})
 endif()
 
+# Qt
+find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS Gui Positioning Qml Quick DBus LinguistTools REQUIRED)
 if(FLAVOR STREQUAL "kirigami" OR FLAVOR STREQUAL "qtcontrols" OR FLAVOR STREQUAL "uuitk")
     find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS Widgets QuickControls2 REQUIRED)
 elseif(FLAVOR STREQUAL "silica")
@@ -70,7 +79,7 @@ elseif(FLAVOR STREQUAL "silica")
     pkg_search_module(SAILFISH sailfishapp REQUIRED)
 endif()
 
-
+# handle request for running from source dir
 if(RUN_FROM_SOURCE)
     set(DATADIR ${CMAKE_CURRENT_SOURCE_DIR})
     set(DATADIR_RUNNING ${DATADIR})
@@ -91,37 +100,64 @@ else()
     endif()
 endif()
 
+# define sources and most of install targets
+
+## extension modules
+file(GLOB GEOCODERS_SRC geocoders/*.json geocoders/*.md geocoders/*.py)
+file(GLOB GEOCODERS_EXTRA LIST_DIRECTORIES false geocoders/test/*)
+install(FILES ${GEOCODERS_SRC} DESTINATION ${DATADIR}/geocoders)
+
+file(GLOB GUIDES_SRC guides/*.json guides/*.md guides/*.qml guides/*.py)
+file(GLOB GUIDES_EXTRA LIST_DIRECTORIES false guides/test/*)
+install(FILES ${GUIDES_SRC} DESTINATION ${DATADIR}/guides)
+
+file(GLOB MAPS_SRC maps/*.json maps/*.md)
+install(FILES ${MAPS_SRC} DESTINATION ${DATADIR}/maps)
+
+file(GLOB ROUTERS_SRC routers/*.json routers/*.md routers/*.qml routers/*.py)
+file(GLOB ROUTERS_EXTRA LIST_DIRECTORIES false routers/test/*)
+install(FILES ${ROUTERS_SRC} DESTINATION ${DATADIR}/routers)
+
+## python sources: installed in subdir
+file(GLOB POOR_SRC poor/*.py)
+
+## QML sources: installed in subdir
+file(GLOB QML_SRC qml/*.qml)
+file(GLOB QML_JS qml/js/*.js)
+file(GLOB QML_PLATFORMS qml/platform.*/*.qml)
+file(GLOB QML_DOCS qml/*.md qml/platform.*/*.md)
+
+## C++ sources
+file(GLOB PM_SRC src/*.cpp)
+file(GLOB PM_HEADERS src/*.h)
+
+# custom target for showing all sources in Qt Creator
+add_custom_target(Sources SOURCES
+    ${GEOCODERS_SRC} ${GEOCODERS_EXTRA}
+    ${GUIDES_SRC} ${GUIDES_EXTRA}
+    ${MAPS_SRC}
+    ${ROUTERS_SRC} ${ROUTERS_EXTRA}
+    ${POOR_SRC}
+    ${QML_SRC} ${QML_JS} ${QML_PLATFORMS} ${QML_DOCS}
+    ${PM_SRC} ${PM_HEADERS}
+    )
+
+# process linking and installation in the subdirs where needed
 add_subdirectory(src)
 add_subdirectory(poor)
 add_subdirectory(thirdparty)
 add_subdirectory(qml)
 add_subdirectory(po)
 
-install(DIRECTORY geocoders
-    DESTINATION ${DATADIR}
-    PATTERN "__pycache__" EXCLUDE
-    PATTERN "test" EXCLUDE)
-install(DIRECTORY guides
-    DESTINATION ${DATADIR}
-    PATTERN "__pycache__" EXCLUDE
-    PATTERN "test" EXCLUDE)
-install(DIRECTORY maps
-    DESTINATION ${DATADIR}
-    PATTERN "__pycache__" EXCLUDE
-    PATTERN "test" EXCLUDE)
-install(DIRECTORY routers
-    DESTINATION ${DATADIR}
-    PATTERN "__pycache__" EXCLUDE
-    PATTERN "test" EXCLUDE)
-
+# appdata
 install(FILES packaging/pure-maps.appdata.xml
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo
     RENAME ${APP_NAME}.appdata.xml)
 
 # desktop files
 if(NOT FLAVOR STREQUAL "silica")
-    configure_file(data/${APP_NAME}.desktop.in ${APP_NAME}.desktop @ONLY)
-    configure_file(data/${APP_NAME}-uri-handler.desktop.in ${APP_NAME}-uri-handler.desktop @ONLY)
+    configure_file(data/pure-maps.desktop.in ${APP_NAME}.desktop @ONLY)
+    configure_file(data/pure-maps-uri-handler.desktop.in ${APP_NAME}-uri-handler.desktop @ONLY)
     set(DESKTOP_SRC
         ${CMAKE_CURRENT_BINARY_DIR}/${APP_NAME}.desktop
         ${CMAKE_CURRENT_BINARY_DIR}/${APP_NAME}-uri-handler.desktop)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,9 +16,9 @@ tools/manage-keys inject .
 make -f Makefile.test
 tools/manage-keys strip .
 git status
-emacs rpm/*.spec pure-maps.pro packaging/click/manifest.json
+emacs rpm/*.spec CMakeLists.txt packaging/click/manifest.json
 emacs NEWS.md packaging/pure-maps.appdata.xml
-git add NEWS.md packaging/click/manifest.json packaging/pure-maps.appdata.xml pure-maps.pro rpm/harbour-pure-maps.spec
+git add NEWS.md packaging/click/manifest.json packaging/pure-maps.appdata.xml CMakeLists.txt rpm/harbour-pure-maps.spec
 git status
 ```
 

--- a/poor/CMakeLists.txt
+++ b/poor/CMakeLists.txt
@@ -1,11 +1,4 @@
-file(GLOB_RECURSE POOR *.py)
-list(FILTER POOR EXCLUDE REGEX "__pycache__|test")
-install(FILES ${POOR} DESTINATION ${DATADIR}/poor)
-# The following _should_ work and would be better than the above GLOB_RECURSE, but for some reason it installs broken symlinks as well instead of just Python files
-#install(DIRECTORY poor
-#	DESTINATION ${DATADIR}
-#	FILES_MATCHING
-#	PATTERN "*.py")
+install(FILES ${POOR_SRC} DESTINATION ${DATADIR}/poor)
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/config.py"
     COMMAND sed -e \'s|pure-maps|${APP_NAME}|g\' ${CMAKE_CURRENT_SOURCE_DIR}/paths.py > ${CMAKE_CURRENT_BINARY_DIR}/paths.py

--- a/qml/CMakeLists.txt
+++ b/qml/CMakeLists.txt
@@ -1,6 +1,6 @@
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    DESTINATION ${DATADIR}
-    PATTERN "platform*" EXCLUDE)
+install(FILES ${QML_SRC} DESTINATION ${DATADIR}/qml)
+install(FILES ${QML_JS} DESTINATION ${DATADIR}/qml/js)
+install(DIRECTORY icons DESTINATION ${DATADIR}/qml)
 
 # We can't just install entire directories, as the kirigami flavor includes symlinked files
 # To remedy this we dereference them first
@@ -9,10 +9,11 @@ set(_RESOLVED_FILES "")
 foreach(_FILE ${_PLATFORM_FILES})
     # Get filename and set resulting file location
     get_filename_component(_FILENAME ${_FILE} NAME)
-    set(_RESULT ${CMAKE_CURRENT_BINARY_DIR}/${_FILENAME})
+    set(_RESULT ${CMAKE_CURRENT_BINARY_DIR}/platform/${_FILENAME})
 
     # Copy and dereference the file
     add_custom_command(OUTPUT ${_RESULT}
+        COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/platform
         COMMAND cp -L -v ${_FILE} ${_RESULT})
     add_custom_target(install_${_FILENAME} ALL
         DEPENDS ${_RESULT})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,43 +17,13 @@ add_compile_options(
     -DDEFAULT_DATA_PREFIX="${DATADIR}/"
     -DQT_DEPRECATED_WARNINGS)
 
-set(SRC
-    main.cpp
-    clipboard.cpp
-    cmdlineparser.cpp
-    commander.cpp
-    config.cpp
-    dbusroot.cpp
-    dbusservice.cpp
-    location.cpp
-    locationmodel.cpp
-    maneuver.cpp
-    maneuvermodel.cpp
-    navigator.cpp
-    navigatordbusadapter.cpp
-    prompt.cpp)
-set(HEADERS
-    clipboard.h
-    cmdlineparser.h
-    commander.h
-    config.h
-    dbusroot.h
-    dbusservice.h
-    location.h
-    locationmodel.h
-    maneuver.h
-    maneuvermodel.h
-    navigator.h
-    navigatordbusadapter.h
-    prompt.h)
-
-if(CMAKE_BUILD_TYPE STREQUAL "release" OR CMAKE_BUILD_TYPE STREQUAL "debug")
+if(CMAKE_BUILD_TYPE STREQUAL "release")
     add_definitions(
         -QT_NO_WARNING_OUTPUT
         -QT_NO_DEBUG_OUTPUT)
 endif()
 
-add_executable(${APP_NAME} ${SRC} ${HEADERS})
+add_executable(${APP_NAME} ${PM_SRC} ${PM_HEADERS})
 
 if(FLAVOR STREQUAL "silica")
     target_include_directories(${APP_NAME} PRIVATE

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,11 +1,9 @@
-install(DIRECTORY geomag/geomag
-    DESTINATION ${DATADIR}/poor
-    FILES_MATCHING PATTERN "*.py")
+file(GLOB GEOMAG_SRC LIST_DIRECTORIES false geomag/geomag/*.py)
+install(FILES ${GEOMAG_SRC} DESTINATION ${DATADIR}/poor/geomag)
 install(FILES geomag/geomag/model_data/WMM.COF
     DESTINATION ${DATADIR}/poor/geomag/model_data)
 
 if(USE_BUNDLED_GPXPY)
-    install(DIRECTORY gpxpy/gpxpy
-        DESTINATION ${DATADIR}/thirdparty/gpxpy
-        PATTERN "__pycache__" EXCLUDE)
+    file(GLOB GPXPY_SRC LIST_DIRECTORIES false gpxpy/gpxpy/*.py)
+    install(FILES ${GPXPY_SRC} DESTINATION ${DATADIR}/poor/gpxpy)
 endif()


### PR DESCRIPTION
/cc @PureTryOut 

Source files are defined in the main folder making it possible to show
them all in the same hierarchy under Qt Creator.

Some reordering of cmake file content was done to push user-specified options to the top
and automatic processing to the later stages. Where feasible, install was done by file
listings as generated by cmake.