### PR TITLE
CMake: Add USE_BUNDLED_GEOMAG option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(RUN_FROM_SOURCE "Run from source, this is mainly intended for easy develo
 set(S2INCLUDES "" CACHE STRING "Custom installed location for s2geometry, includes")
 set(S2LIBS "" CACHE STRING "Custom installed location for s2geometry, libs")
 option(USE_BUNDLED_GPXPY "Use a bundled version of GPXPY rather than a system-wide version" ON)
+option(USE_BUNDLED_GEOMAG "Use a bundled version of geomag rather than a system-wide version" ON)
 option(USE_BUNDLED_GEOCLUE2 "Use a bundled version of Geoclue2 Qt plugin with bugfixes" OFF)
 set(QML_IMPORT_PATH "" CACHE STRING "Additional QML import path")
 

--- a/poor/magfield.py
+++ b/poor/magfield.py
@@ -18,7 +18,10 @@
 """Calculates magnetic declination."""
 
 from datetime import datetime, timedelta
-from poor.geomag import WorldMagneticModel
+try:
+    from poor.geomag import WorldMagneticModel
+except ImportError:
+    from geomag import WorldMagneticModel
 
 __all__ = ("MagField")
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,7 +1,9 @@
-file(GLOB GEOMAG_SRC LIST_DIRECTORIES false geomag/geomag/*.py)
-install(FILES ${GEOMAG_SRC} DESTINATION ${DATADIR}/poor/geomag)
-install(FILES geomag/geomag/model_data/WMM.COF
-    DESTINATION ${DATADIR}/poor/geomag/model_data)
+if(USE_BUNDLED_GEOMAG)
+    file(GLOB GEOMAG_SRC LIST_DIRECTORIES false geomag/geomag/*.py)
+    install(FILES ${GEOMAG_SRC} DESTINATION ${DATADIR}/poor/geomag)
+    install(FILES geomag/geomag/model_data/WMM.COF
+        DESTINATION ${DATADIR}/poor/geomag/model_data)
+endif()
 
 if(USE_BUNDLED_GPXPY)
     file(GLOB GPXPY_SRC LIST_DIRECTORIES false gpxpy/gpxpy/*.py)


### PR DESCRIPTION
Add a CMake build option for using the geomag python module from system directories. Also, try to import first the bundled geomag module and if that fails, try the system provided one.

This is patch is used in the WIP Debian packages of pure-maps [here](https://salsa.debian.org/Mobian-team/puremaps-packaging).