### PR TITLE
fix My Backup configuration

### DIFF
--- a/data/harbour-pure-maps.desktop
+++ b/data/harbour-pure-maps.desktop
@@ -6,4 +6,4 @@ Type=Application
 X-Nemo-Application-Type=silica-qt5
 
 [X-HarbourBackup]
-BackupPathList=.config/harbour-pure-maps
+BackupPathList=.config/harbour-pure-maps/


### PR DESCRIPTION
Directories needs to end with slash. Tested with My Backup 1.0.5. 
When ending slash is missing, My Backup just skip it and logs:

/home/defaultuser/.config/harbour-pure-maps is not a file