### PR TITLE
Replace mapbox-gl-native by maplibre-gl-native in click packaging

### DIFF
--- a/fix-compilation-with-clickable.patch
+++ b/fix-compilation-with-clickable.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 01f62a1a8..71db29e2f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -86,7 +86,7 @@ target_link_libraries(
+ 
+ cmake_policy(SET CMP0063 NEW)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+-set(CMAKE_CXX_STANDARD 17)
++set(CMAKE_CXX_STANDARD 14)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+ set(CMAKE_C_EXTENSIONS OFF)
+diff --git a/platform/qt/src/http_file_source.cpp b/platform/qt/src/http_file_source.cpp
+index a2a13c5e1..a4ac0c58e 100644
+--- a/platform/qt/src/http_file_source.cpp
++++ b/platform/qt/src/http_file_source.cpp
+@@ -45,7 +45,8 @@ void HTTPFileSource::Impl::request(HTTPRequest* req)
+ #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+     connect(data.first, &QNetworkReply::errorOccurred, this, &HTTPFileSource::Impl::onReplyFinished);
+ #else
+-    connect(data.first, &QNetworkReply::error, this, &HTTPFileSource::Impl::onReplyFinished);
++    connect(data.first, SIGNAL(error()), this, SLOT(onReplyFinished()));
++    //connect(data.first, &QNetworkReply::error, this, &HTTPFileSource::Impl::onReplyFinished);
+ #endif
+ }
+ 

--- a/packaging/click/full-build.yaml
+++ b/packaging/click/full-build.yaml
@@ -22,9 +22,10 @@ dependencies_ppa:
 dependencies_host:
 - cmake
 
+install_qml:
+- ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/MapboxMap
 install_lib:
-- ${MAPBOX_GL_NATIVE_LIB_INSTALL_DIR}/lib/*.so*
-- ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/*
+- ${MAPLIBRE_GL_NATIVE_LIB_INSTALL_DIR}/lib/libQMapboxGL.so*
 - ${S2GEOMETRY_LIB_INSTALL_DIR}/lib/*.so*
 install_bin:
 - ${MIMIC_LIB_INSTALL_DIR}/bin/mimic
@@ -38,25 +39,42 @@ install_data:
   ${PICOTTS_LIB_INSTALL_DIR}/usr/share/picotts: usr/share
 
 libraries:
-  mapbox-gl-native:
+  maplibre-gl-native:
     builder: cmake
     build_args:
     - -DMBGL_WITH_QT=ON
     - -DMBGL_WITH_WERROR=OFF
     - -DMBGL_WITH_QT_HEADLESS=OFF
-    - -DMBGL_WITH_QT_TEST=OFF
-    - -DMBGL_WITH_QT_DEMO=OFF
+    - -DMBGL_QT_LIBRARY_ONLY=ON
+    - -DMBGL_QT_STATIC=OFF
+
+    image_setup:
+      run:
+      - ln -s android-23 /usr/include/android
+      - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+      - apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main"
+      - apt-get update
+      - apt-get install -y clang-12 lld-12
+      - update-alternatives --install /usr/bin/cc cc /usr/bin/clang-12 60
+      - update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-12 60
+      - mkdir /opt/cmake
+      - wget https://github.com/Kitware/CMake/releases/download/v3.22.3/cmake-3.22.3-linux-x86_64.sh -O cmake-installer.sh
+      - sh cmake-installer.sh --skip-license --prefix=/opt/cmake
+      - rm cmake-installer.sh
+      env:
+        CC: clang-12
+        CXX: clang++-12
+        PATH: /opt/cmake/bin:$PATH
+
+  mapbox-gl-qml:
+    builder: cmake
+    build_args:
+    - -DCMAKE_CXX_STANDARD=14
+
     dependencies_ppa:
     - ppa:janisozaur/cmake-update
     dependencies_host:
     - cmake
-
-  mapbox-gl-qml:
-    builder: qmake
-    build_args:
-    - INCLUDEPATH+=${BUILD_DIR}/../mapbox-gl-native/install/include
-    - INCLUDEPATH+=${BUILD_DIR}/../mapbox-gl-native/install/include/qt5
-    - LIBS+=-L${BUILD_DIR}/../mapbox-gl-native/install/lib
 
   s2geometry:
     builder: cmake

--- a/packaging/click/patches/maplibre-gl-native/disable-armhf-version-check.patch
+++ b/packaging/click/patches/maplibre-gl-native/disable-armhf-version-check.patch
@@ -1,0 +1,14 @@
+diff --git a/platform/qt/qt.cmake b/platform/qt/qt.cmake
+index cb11d5352..1e7411df3 100644
+--- a/platform/qt/qt.cmake
++++ b/platform/qt/qt.cmake
+@@ -226,7 +226,8 @@ configure_package_config_file(
+ 
+ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/QMapboxGLConfigVersion.cmake
+ 	VERSION ${MBGL_QT_VERSION}
+-	COMPATIBILITY AnyNewerVersion)
++	COMPATIBILITY AnyNewerVersion
++        ARCH_INDEPENDENT)
+ 
+ install(EXPORT QMapboxGLTargets
+ 	DESTINATION ${CMAKECONFIG_INSTALL_DIR}

--- a/packaging/click/patches/maplibre-gl-native/enable-clang-cross-compiling.patch
+++ b/packaging/click/patches/maplibre-gl-native/enable-clang-cross-compiling.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 71db29e2f..69ca6d4bc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,6 +24,27 @@ set(
+     "--leak-check=full --gen-suppressions=all --error-exitcode=1 --suppressions=${PROJECT_SOURCE_DIR}/scripts/valgrind.sup"
+ )
+ 
++set(CROSS_COMPILING OFF)
++
++if($ENV{ARCH} STREQUAL "armhf")
++    set(CROSS_COMPILING ON)
++    set(CMAKE_SYSTEM_PROCESSOR arm)
++elseif($ENV{ARCH} STREQUAL "arm64")
++    set(CROSS_COMPILING ON)
++    set(CMAKE_SYSTEM_PROCESSOR aarch64)
++endif()
++
++if(CROSS_COMPILING)
++    set(CMAKE_SYSTEM_NAME Linux)
++
++    set(CMAKE_PREFIX_PATH /usr/lib/$ENV{ARCH_TRIPLET};/usr/lib/$ENV{ARCH_TRIPLET}/cmake)
++    set(CMAKE_C_COMPILER_TARGET $ENV{ARCH_TRIPLET})
++    set(CMAKE_CXX_COMPILER_TARGET $ENV{ARCH_TRIPLET})
++
++    set(ICU_INCLUDE_DIR /usr/include/$ENV{ARCH_TRIPLET})
++    find_package(ICU REQUIRED COMPONENTS uc)
++endif()
++
+ include(CTest)
+ 
+ if(NOT CMAKE_BUILD_TYPE)

--- a/packaging/click/patches/maplibre-gl-native/fix-compilation-with-clickable.patch
+++ b/packaging/click/patches/maplibre-gl-native/fix-compilation-with-clickable.patch
@@ -1,0 +1,27 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 01f62a1a8..71db29e2f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -86,7 +86,7 @@ target_link_libraries(
+ 
+ cmake_policy(SET CMP0063 NEW)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+-set(CMAKE_CXX_STANDARD 17)
++set(CMAKE_CXX_STANDARD 14)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+ set(CMAKE_C_EXTENSIONS OFF)
+diff --git a/platform/qt/src/http_file_source.cpp b/platform/qt/src/http_file_source.cpp
+index a2a13c5e1..a4ac0c58e 100644
+--- a/platform/qt/src/http_file_source.cpp
++++ b/platform/qt/src/http_file_source.cpp
+@@ -45,7 +45,8 @@ void HTTPFileSource::Impl::request(HTTPRequest* req)
+ #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+     connect(data.first, &QNetworkReply::errorOccurred, this, &HTTPFileSource::Impl::onReplyFinished);
+ #else
+-    connect(data.first, &QNetworkReply::error, this, &HTTPFileSource::Impl::onReplyFinished);
++    connect(data.first, SIGNAL(error()), this, SLOT(onReplyFinished()));
++    //connect(data.first, &QNetworkReply::error, this, &HTTPFileSource::Impl::onReplyFinished);
+ #endif
+ }
+ 

--- a/packaging/click/prepare-deps.sh
+++ b/packaging/click/prepare-deps.sh
@@ -7,7 +7,7 @@ set -Eeuo pipefail
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 CLONE_ARGS="--recursive --shallow-submodules --depth 1"
-MAPBOX_GL_NATIVE_SRC_DIR=$ROOT_DIR/libs/mapbox-gl-native
+MAPLIBRE_GL_NATIVE_SRC_DIR=$ROOT_DIR/libs/maplibre-gl-native
 MAPBOX_GL_QML_SRC_DIR=$ROOT_DIR/libs/mapbox-gl-qml
 QMLRUNNER_SRC_DIR=$ROOT_DIR/libs/qmlrunner
 MIMIC_SRC_DIR=$ROOT_DIR/libs/mimic
@@ -16,11 +16,11 @@ PICOTTS_SRC_DIR=$ROOT_DIR/libs/picotts
 S2GEOMETRY_SRC_DIR=$ROOT_DIR/libs/s2geometry
 
 # Remove old downloads
-rm -rf $MAPBOX_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $QMLRUNNER_SRC_DIR $MIMIC_SRC_DIR $PICOTTS_SRC_DIR $S2GEOMETRY_SRC_DIR
+rm -rf $MAPLIBRE_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $QMLRUNNER_SRC_DIR $MIMIC_SRC_DIR $PICOTTS_SRC_DIR $S2GEOMETRY_SRC_DIR
 
 # Download sources
-git clone -b mapbox-update-200607 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-native.git $MAPBOX_GL_NATIVE_SRC_DIR
-git clone -b 1.7.5 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
+git clone -b main ${CLONE_ARGS} https://github.com/maplibre/maplibre-gl-native.git $MAPLIBRE_GL_NATIVE_SRC_DIR
+git clone -b 2.0.1 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
 git clone -b 1.0.2 ${CLONE_ARGS} https://github.com/rinigus/qmlrunner.git $QMLRUNNER_SRC_DIR
 git clone -b 0.9.0+git2 ${CLONE_ARGS} https://github.com/rinigus/s2geometry.git $S2GEOMETRY_SRC_DIR
 
@@ -31,3 +31,7 @@ fi
 if [ "$ENABLE_PICOTTS" == "1" ] ; then
 	git clone ${CLONE_ARGS} https://github.com/jonnius/pkg-picotts.git $PICOTTS_SRC_DIR
 fi
+
+# Apply patches
+cd $MAPLIBRE_GL_NATIVE_SRC_DIR
+git apply $ROOT_DIR/packaging/click/patches/maplibre-gl-native/*.patch

--- a/packaging/click/slim-build.yaml
+++ b/packaging/click/slim-build.yaml
@@ -22,9 +22,10 @@ dependencies_ppa:
 dependencies_host:
 - cmake
 
+install_qml:
+- ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/MapboxMap
 install_lib:
-- ${MAPBOX_GL_NATIVE_LIB_INSTALL_DIR}/lib/*.so*
-- ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/*
+- ${MAPLIBRE_GL_NATIVE_LIB_INSTALL_DIR}/lib/libQMapboxGL.so*
 - ${S2GEOMETRY_LIB_INSTALL_DIR}/lib/*.so*
 install_bin:
 - ${PICOTTS_LIB_INSTALL_DIR}/usr/bin/pico2wave
@@ -37,25 +38,42 @@ install_data:
   ${PICOTTS_LIB_INSTALL_DIR}/usr/share/picotts: usr/share
 
 libraries:
-  mapbox-gl-native:
+  maplibre-gl-native:
     builder: cmake
     build_args:
     - -DMBGL_WITH_QT=ON
     - -DMBGL_WITH_WERROR=OFF
     - -DMBGL_WITH_QT_HEADLESS=OFF
-    - -DMBGL_WITH_QT_TEST=OFF
-    - -DMBGL_WITH_QT_DEMO=OFF
+    - -DMBGL_QT_LIBRARY_ONLY=ON
+    - -DMBGL_QT_STATIC=OFF
+
+    image_setup:
+      run:
+      - ln -s android-23 /usr/include/android
+      - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+      - apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main"
+      - apt-get update
+      - apt-get install -y clang-12 lld-12
+      - update-alternatives --install /usr/bin/cc cc /usr/bin/clang-12 60
+      - update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-12 60
+      - mkdir /opt/cmake
+      - wget https://github.com/Kitware/CMake/releases/download/v3.22.3/cmake-3.22.3-linux-x86_64.sh -O cmake-installer.sh
+      - sh cmake-installer.sh --skip-license --prefix=/opt/cmake
+      - rm cmake-installer.sh
+      env:
+        CC: clang-12
+        CXX: clang++-12
+        PATH: /opt/cmake/bin:$PATH
+
+  mapbox-gl-qml:
+    builder: cmake
+    build_args:
+    - -DCMAKE_CXX_STANDARD=14
+
     dependencies_ppa:
     - ppa:janisozaur/cmake-update
     dependencies_host:
     - cmake
-
-  mapbox-gl-qml:
-    builder: qmake
-    build_args:
-    - INCLUDEPATH+=${BUILD_DIR}/../mapbox-gl-native/install/include
-    - INCLUDEPATH+=${BUILD_DIR}/../mapbox-gl-native/install/include/qt5
-    - LIBS+=-L${BUILD_DIR}/../mapbox-gl-native/install/lib
 
   s2geometry:
     builder: cmake


### PR DESCRIPTION
For click packaging, this MR
* replaces `mapbox-gl-native` by `maplibre-gl-native`
* adds patches to `maplibre-gl-native` for cross compiling on Ubuntu 16.04
* adds build config patch to `maplibre-gl-native` for cross compiling with clang
* updates `mapbox-gl-qml` to 2.0.1