### PR TITLE
Update click packaging

### DIFF
--- a/packaging/click/full-build.yaml
+++ b/packaging/click/full-build.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 7.0.1
+clickable_minimum_required: 7.4.0
 
 scripts:
   prepare-deps: git submodule update --recursive --init && ENABLE_MIMIC=1 ${ROOT}/packaging/click/prepare-deps.sh
@@ -17,10 +17,6 @@ postbuild:
 - sed -i 's/@APP_TITLE@/Pure Maps/g' ${INSTALL_DIR}/manifest.json
 - sed -i 's/@APP_NAME@/pure-maps/g'  ${INSTALL_DIR}/manifest.json
 - mv ${INSTALL_DIR}/bin/pure-maps.jonnius ${CLICK_PATH}/pure-maps
-dependencies_ppa:
-- ppa:janisozaur/cmake-update
-dependencies_host:
-- cmake
 
 install_qml:
 - ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/MapboxMap
@@ -57,24 +53,14 @@ libraries:
       - apt-get install -y clang-12 lld-12
       - update-alternatives --install /usr/bin/cc cc /usr/bin/clang-12 60
       - update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-12 60
-      - mkdir /opt/cmake
-      - wget https://github.com/Kitware/CMake/releases/download/v3.22.3/cmake-3.22.3-linux-x86_64.sh -O cmake-installer.sh
-      - sh cmake-installer.sh --skip-license --prefix=/opt/cmake
-      - rm cmake-installer.sh
       env:
         CC: clang-12
         CXX: clang++-12
-        PATH: /opt/cmake/bin:$PATH
 
   mapbox-gl-qml:
     builder: cmake
     build_args:
     - -DCMAKE_CXX_STANDARD=14
-
-    dependencies_ppa:
-    - ppa:janisozaur/cmake-update
-    dependencies_host:
-    - cmake
 
   s2geometry:
     builder: cmake
@@ -83,10 +69,6 @@ libraries:
     - -DBUILD_TESTING=OFF
     - -DBUILD_SHARED_LIBS=ON
     - -DBUILD_EXAMPLES=OFF
-    dependencies_ppa:
-    - ppa:janisozaur/cmake-update
-    dependencies_host:
-    - cmake
     dependencies_target:
     - swig
     - libpython3-dev

--- a/packaging/click/full-build.yaml
+++ b/packaging/click/full-build.yaml
@@ -21,7 +21,7 @@ postbuild:
 install_qml:
 - ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/MapboxMap
 install_lib:
-- ${MAPLIBRE_GL_NATIVE_LIB_INSTALL_DIR}/lib/libQMapboxGL.so*
+- ${MAPLIBRE_GL_NATIVE_LIB_INSTALL_DIR}/lib/libQMapLibreGL.so*
 - ${S2GEOMETRY_LIB_INSTALL_DIR}/lib/*.so*
 install_bin:
 - ${MIMIC_LIB_INSTALL_DIR}/bin/mimic

--- a/packaging/click/patches/maplibre-gl-native/disable-armhf-version-check.patch
+++ b/packaging/click/patches/maplibre-gl-native/disable-armhf-version-check.patch
@@ -4,11 +4,11 @@ index cb11d5352..1e7411df3 100644
 +++ b/platform/qt/qt.cmake
 @@ -226,7 +226,8 @@ configure_package_config_file(
  
- write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/QMapboxGLConfigVersion.cmake
- 	VERSION ${MBGL_QT_VERSION}
--	COMPATIBILITY AnyNewerVersion)
-+	COMPATIBILITY AnyNewerVersion
-+        ARCH_INDEPENDENT)
+ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/QMapLibreGLConfigVersion.cmake
+     VERSION ${MBGL_QT_VERSION}
+-    COMPATIBILITY AnyNewerVersion)
++    COMPATIBILITY AnyNewerVersion
++    ARCH_INDEPENDENT)
  
- install(EXPORT QMapboxGLTargets
- 	DESTINATION ${CMAKECONFIG_INSTALL_DIR}
+ install(EXPORT QMapLibreGLTargets
+     DESTINATION ${CMAKECONFIG_INSTALL_DIR}

--- a/packaging/click/patches/maplibre-gl-native/fix-compilation-with-clickable.patch
+++ b/packaging/click/patches/maplibre-gl-native/fix-compilation-with-clickable.patch
@@ -11,10 +11,10 @@ index 01f62a1a8..71db29e2f 100644
  set(CMAKE_CXX_STANDARD_REQUIRED ON)
  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
  set(CMAKE_C_EXTENSIONS OFF)
-diff --git a/platform/qt/src/http_file_source.cpp b/platform/qt/src/http_file_source.cpp
+diff --git a/platform/qt/src/mbgl/http_file_source.cpp b/platform/qt/src/mbgl/http_file_source.cpp
 index a2a13c5e1..a4ac0c58e 100644
---- a/platform/qt/src/http_file_source.cpp
-+++ b/platform/qt/src/http_file_source.cpp
+--- a/platform/qt/src/mbgl/http_file_source.cpp
++++ b/platform/qt/src/mbgl/http_file_source.cpp
 @@ -45,7 +45,8 @@ void HTTPFileSource::Impl::request(HTTPRequest* req)
  #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
      connect(data.first, &QNetworkReply::errorOccurred, this, &HTTPFileSource::Impl::onReplyFinished);

--- a/packaging/click/prepare-deps.sh
+++ b/packaging/click/prepare-deps.sh
@@ -20,7 +20,7 @@ rm -rf $MAPLIBRE_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $QMLRUNNER_SRC_DIR $MI
 
 # Download sources
 git clone -b main ${CLONE_ARGS} https://github.com/maplibre/maplibre-gl-native.git $MAPLIBRE_GL_NATIVE_SRC_DIR
-git clone -b 2.0.1 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
+git clone -b 2.1.0 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
 git clone -b 1.0.2 ${CLONE_ARGS} https://github.com/rinigus/qmlrunner.git $QMLRUNNER_SRC_DIR
 git clone -b 0.9.0+git2 ${CLONE_ARGS} https://github.com/rinigus/s2geometry.git $S2GEOMETRY_SRC_DIR
 

--- a/packaging/click/slim-build.yaml
+++ b/packaging/click/slim-build.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 7.0.1
+clickable_minimum_required: 7.4.0
 
 scripts:
   prepare-deps: git submodule update --recursive --init && ENABLE_MIMIC=0 ${ROOT}/packaging/click/prepare-deps.sh
@@ -17,10 +17,6 @@ postbuild:
 - sed -i 's/@APP_TITLE@/Pure Maps Slim/g' ${INSTALL_DIR}/manifest.json
 - sed -i 's/@APP_NAME@/pure-maps-slim/g'  ${INSTALL_DIR}/manifest.json
 - mv ${INSTALL_DIR}/bin/pure-maps-slim.jonnius ${CLICK_PATH}/pure-maps
-dependencies_ppa:
-- ppa:janisozaur/cmake-update
-dependencies_host:
-- cmake
 
 install_qml:
 - ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/MapboxMap
@@ -56,24 +52,14 @@ libraries:
       - apt-get install -y clang-12 lld-12
       - update-alternatives --install /usr/bin/cc cc /usr/bin/clang-12 60
       - update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-12 60
-      - mkdir /opt/cmake
-      - wget https://github.com/Kitware/CMake/releases/download/v3.22.3/cmake-3.22.3-linux-x86_64.sh -O cmake-installer.sh
-      - sh cmake-installer.sh --skip-license --prefix=/opt/cmake
-      - rm cmake-installer.sh
       env:
         CC: clang-12
         CXX: clang++-12
-        PATH: /opt/cmake/bin:$PATH
 
   mapbox-gl-qml:
     builder: cmake
     build_args:
     - -DCMAKE_CXX_STANDARD=14
-
-    dependencies_ppa:
-    - ppa:janisozaur/cmake-update
-    dependencies_host:
-    - cmake
 
   s2geometry:
     builder: cmake
@@ -82,10 +68,6 @@ libraries:
     - -DBUILD_TESTING=OFF
     - -DBUILD_SHARED_LIBS=ON
     - -DBUILD_EXAMPLES=OFF
-    dependencies_ppa:
-    - ppa:janisozaur/cmake-update
-    dependencies_host:
-    - cmake
     dependencies_target:
     - swig
     - libpython3-dev

--- a/packaging/click/slim-build.yaml
+++ b/packaging/click/slim-build.yaml
@@ -21,7 +21,7 @@ postbuild:
 install_qml:
 - ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/MapboxMap
 install_lib:
-- ${MAPLIBRE_GL_NATIVE_LIB_INSTALL_DIR}/lib/libQMapboxGL.so*
+- ${MAPLIBRE_GL_NATIVE_LIB_INSTALL_DIR}/lib/libQMapLibreGL.so*
 - ${S2GEOMETRY_LIB_INSTALL_DIR}/lib/*.so*
 install_bin:
 - ${PICOTTS_LIB_INSTALL_DIR}/usr/bin/pico2wave


### PR DESCRIPTION
This PR
- updates maplibre-gl-native patches to work with latest main branch
- updates mapbox-gl-qml to 2.1.0
- removes clickable instructions to update CMake, because Clickable now ships recent CMake 3.22.3