### PR TITLE
Update mapbox gl qml to 2.1.1 in click package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ tools/apikeys.py
 /build/
 /qml/platform
 /.clickable/
-/clickable.json
+/clickable.yaml

--- a/packaging/click/prepare-deps.sh
+++ b/packaging/click/prepare-deps.sh
@@ -19,7 +19,7 @@ S2GEOMETRY_SRC_DIR=$ROOT_DIR/libs/s2geometry
 rm -rf $MAPLIBRE_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $QMLRUNNER_SRC_DIR $MIMIC_SRC_DIR $PICOTTS_SRC_DIR $S2GEOMETRY_SRC_DIR
 
 # Download sources
-git clone -b main ${CLONE_ARGS} https://github.com/maplibre/maplibre-gl-native.git $MAPLIBRE_GL_NATIVE_SRC_DIR
+git clone -b qt-v2.0.1 ${CLONE_ARGS} https://github.com/maplibre/maplibre-gl-native.git $MAPLIBRE_GL_NATIVE_SRC_DIR
 git clone -b 2.1.1 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
 git clone -b 1.0.2 ${CLONE_ARGS} https://github.com/rinigus/qmlrunner.git $QMLRUNNER_SRC_DIR
 git clone -b 0.9.0+git2 ${CLONE_ARGS} https://github.com/rinigus/s2geometry.git $S2GEOMETRY_SRC_DIR

--- a/packaging/click/prepare-deps.sh
+++ b/packaging/click/prepare-deps.sh
@@ -20,7 +20,7 @@ rm -rf $MAPLIBRE_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $QMLRUNNER_SRC_DIR $MI
 
 # Download sources
 git clone -b main ${CLONE_ARGS} https://github.com/maplibre/maplibre-gl-native.git $MAPLIBRE_GL_NATIVE_SRC_DIR
-git clone -b 2.1.0 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
+git clone -b 2.1.1 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
 git clone -b 1.0.2 ${CLONE_ARGS} https://github.com/rinigus/qmlrunner.git $QMLRUNNER_SRC_DIR
 git clone -b 0.9.0+git2 ${CLONE_ARGS} https://github.com/rinigus/s2geometry.git $S2GEOMETRY_SRC_DIR
 


### PR DESCRIPTION
Updates mapbox gl qml plugin to 2.1.1 in click package to address https://github.com/maplibre/maplibre-gl-native/issues/548.

Also updates gitignore file to account for the renamed clickable project config file.