### PR TITLE
Ensure pico2wave is installed in click build

### DIFF
--- a/packaging/click/full-build.yaml
+++ b/packaging/click/full-build.yaml
@@ -66,6 +66,7 @@ libraries:
     build:
     - cp -r ${SRC_DIR}/* ${BUILD_DIR}/
     - DESTDIR=${INSTALL_DIR} LANG_DIR=./usr/share/picotts/lang make -j${NUM_PROCS}
+    - touch pico2wave
     - DESTDIR=${INSTALL_DIR} make install
     dependencies_target:
     - libtool

--- a/packaging/click/slim-build.yaml
+++ b/packaging/click/slim-build.yaml
@@ -65,6 +65,7 @@ libraries:
     build:
     - cp -r ${SRC_DIR}/* ${BUILD_DIR}/
     - DESTDIR=${INSTALL_DIR} LANG_DIR=./usr/share/picotts/lang make -j${NUM_PROCS}
+    - touch pico2wave
     - DESTDIR=${INSTALL_DIR} make install
     dependencies_target:
     - libtool


### PR DESCRIPTION
Picotts' makefile doesn't see a need to install again (`make: 'install' is up to date.`) when asked to. Touching the file ensures it is indeed installed.

The issue being solved here can be reproduced by building twice in a row:
```bash
clickable build --libs picotts
clickable build --libs picotts
```
Then `build/x86_64-linux-gnu/picotts/install/` is empty.