### PR TITLE
Add Ordnance Survey (UK) maps

### DIFF
--- a/maps/osgb_outdoor.json
+++ b/maps/osgb_outdoor.json
@@ -1,0 +1,13 @@
+{
+  "attribution": {
+    "© Ordnance Survey": "https://www.ordnancesurvey.co.uk",
+    "Contains OS Data © Crown Copyright and database rights 2024" : "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+  },
+  "format": "raster",
+  "keys": ["OS_APIKEY"],
+  "name": "OSGB Outdoor",
+  "profiles": ["mixed", "online"],
+  "tile_size": 256,
+  "provider": "Ordnance Survey Outdoor",
+  "tile_url": "https://api.os.uk/maps/raster/v1/zxy/Outdoor_3857/{z}/{x}/{y}.png?key=#OS_APIKEY#"
+}

--- a/maps/osgb_roads.json
+++ b/maps/osgb_roads.json
@@ -1,0 +1,13 @@
+{
+  "attribution": {
+    "© Ordnance Survey": "https://www.ordnancesurvey.co.uk",
+    "Contains OS Data © Crown Copyright and database rights 2024" : "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+  },
+  "format": "raster",
+  "keys": ["OS_APIKEY"],
+  "name": "OSGB Outdoor",
+  "profiles": ["mixed", "online"],
+  "tile_size": 256,
+  "provider": "Ordnance Survey Roads",
+  "tile_url": "https://api.os.uk/maps/raster/v1/zxy/Road_3857/{z}/{x}/{y}.png?key=#OS_APIKEY#"
+}

--- a/poor/apikeys.py
+++ b/poor/apikeys.py
@@ -20,4 +20,7 @@ Keys = {
 
     # https://docs.stadiamaps.com/
     "STADIAMAPS_KEY": "",
+
+    # https://www.ordnancesurvey.co.uk
+    "OS_APIKEY": ""
 }

--- a/poor/keystore.py
+++ b/poor/keystore.py
@@ -50,7 +50,10 @@ KEYNAMES = [
     "OPENCAGE_KEY",
 
     # https://docs.stadiamaps.com/
-    "STADIAMAPS_KEY"
+    "STADIAMAPS_KEY",
+
+    # https://osdatahub.os.uk/
+    "OS_APIKEY"
 ]
 
 HEADERS = {
@@ -60,7 +63,8 @@ HEADERS = {
     "MAPQUEST": HeaderDesc(_('Register at <a href="https://developer.mapquest.com">https://developer.mapquest.com</a> and create your own API key'), "MapQuest"),
     "OPENCAGE": HeaderDesc(_('Register at <a href="https://opencagedata.com">https://opencagedata.com</a> and create your own API key'), "OpenCage"),
     "STADIAMAPS": HeaderDesc(_('Register at <a href="https://stadiamaps.com">https://stadiamaps.com</a> and create your own API key'), "Stadia Maps"),
-    "HERE": HeaderDesc(_('Register at <a href="https://developer.here.com">https://developer.here.com</a> and create your own App API Key'), "HERE")
+    "HERE": HeaderDesc(_('Register at <a href="https://developer.here.com">https://developer.here.com</a> and create your own App API Key'), "HERE"),
+    "OS": HeaderDesc(_('Register at <a href="https://osdatahub.os.uk/">https://osdatahub.os.uk</a> and create your own App API Key'), "Ordnance Survey")
 }
 
 KEYDESC = {
@@ -84,6 +88,9 @@ KEYDESC = {
 
     # here.com
     "HERE_APIKEY": _("HERE API Key"),
+
+    # www.ordnancesurvey.co.uk 
+    "OS_APIKEY": _("Ordnance Survey API Key"),
 }
 
 # List of keys that are made available only after end user license is


### PR DESCRIPTION
This adds json files for the Ordnance Survey maps API (https://www.ordnancesurvey.co.uk/products/os-maps-api#get) for used in mixed or online mode. An api key definition for these maps is added to the keystore and apikeys .py files 

These map tiles are available on a free plan (with an API key signup process). They provide a reasonable level of detail and are useful if OSM Scout is not installed. They do only cover the UK. 