### PR TITLE
cmake: Add find_package() call for S2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,9 @@ elseif(FLAVOR STREQUAL "silica")
     pkg_search_module(SAILFISH sailfishapp REQUIRED)
 endif()
 
+# s2
+find_package(s2 REQUIRED)
+
 # handle request for running from source dir
 if(RUN_FROM_SOURCE)
     set(DATADIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,7 @@ target_link_libraries(${APP_NAME}
     Qt5::Quick
     Qt5::Positioning
     Qt5::DBus
-    s2)
+    s2::s2)
 
 set(LINKING_FLAVORS
     "kirigami"


### PR DESCRIPTION
This fixes build failure with s2geometry 0.11.1.