### PR TITLE
Switch s2geometry to upstream v0.11.1 for click build

### DIFF
--- a/packaging/click/full-build.yaml
+++ b/packaging/click/full-build.yaml
@@ -23,7 +23,6 @@ install_qml:
 - ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/MapboxMap
 install_lib:
 - ${MAPLIBRE_GL_NATIVE_LIB_INSTALL_DIR}/lib/libQMapLibreGL.so*
-- ${S2GEOMETRY_LIB_INSTALL_DIR}/lib/*.so*
 install_bin:
 - ${MIMIC_LIB_INSTALL_DIR}/bin/mimic
 - ${PICOTTS_LIB_INSTALL_DIR}/usr/bin/pico2wave
@@ -50,12 +49,16 @@ libraries:
     build_args:
     - -DCMAKE_CXX_STANDARD=14
 
+  abseil:
+    builder: cmake
+    build_args:
+    - -DABSL_ENABLE_INSTALL=ON
+
   s2geometry:
     builder: cmake
     build_args:
-    - -DBUILD_PYTHON=OFF
-    - -DBUILD_TESTING=OFF
-    - -DBUILD_SHARED_LIBS=ON
+    - -DBUILD_TESTS=OFF
+    - -DBUILD_SHARED_LIBS=OFF
     - -DBUILD_EXAMPLES=OFF
     dependencies_target:
     - swig

--- a/packaging/click/patches/abseil/0002-Remove-maes-option-from-cross-compilation.patch
+++ b/packaging/click/patches/abseil/0002-Remove-maes-option-from-cross-compilation.patch
@@ -1,0 +1,39 @@
+From d25cf3b9aa873595a19e197cc29ab46c0093bff1 Mon Sep 17 00:00:00 2001
+From: Sinan Kaya <sinan.kaya@microsoft.com>
+Date: Mon, 3 Feb 2020 03:25:57 +0000
+Subject: [PATCH 2/3] Remove maes option from cross-compilation
+
+---
+Upstream-Status: Pending
+
+ absl/copts/GENERATED_AbseilCopts.cmake | 4 ----
+ absl/copts/GENERATED_copts.bzl         | 4 ----
+ 2 files changed, 8 deletions(-)
+
+diff --git a/absl/copts/GENERATED_AbseilCopts.cmake b/absl/copts/GENERATED_AbseilCopts.cmake
+index a4ab1aa2041e..23b9253c1f00 100644
+--- a/absl/copts/GENERATED_AbseilCopts.cmake
++++ b/absl/copts/GENERATED_AbseilCopts.cmake
+@@ -158,7 +158,3 @@ list(APPEND ABSL_RANDOM_HWAES_ARM64_FLAGS
+ list(APPEND ABSL_RANDOM_HWAES_MSVC_X64_FLAGS
+ )
+ 
+-list(APPEND ABSL_RANDOM_HWAES_X64_FLAGS
+-    "-maes"
+-    "-msse4.1"
+-)
+diff --git a/absl/copts/GENERATED_copts.bzl b/absl/copts/GENERATED_copts.bzl
+index a6efc98e11d4..1e847f769501 100644
+--- a/absl/copts/GENERATED_copts.bzl
++++ b/absl/copts/GENERATED_copts.bzl
+@@ -159,7 +159,3 @@ ABSL_RANDOM_HWAES_ARM64_FLAGS = [
+ ABSL_RANDOM_HWAES_MSVC_X64_FLAGS = [
+ ]
+ 
+-ABSL_RANDOM_HWAES_X64_FLAGS = [
+-    "-maes",
+-    "-msse4.1",
+-]
+-- 
+2.36.1
+

--- a/packaging/click/prepare-deps.sh
+++ b/packaging/click/prepare-deps.sh
@@ -13,16 +13,18 @@ QMLRUNNER_SRC_DIR=$ROOT_DIR/libs/qmlrunner
 MIMIC_SRC_DIR=$ROOT_DIR/libs/mimic
 MIMIC_VERSION="1.3.0.1"
 PICOTTS_SRC_DIR=$ROOT_DIR/libs/picotts
+ABSEIL_SRC_DIR=$ROOT_DIR/libs/abseil
 S2GEOMETRY_SRC_DIR=$ROOT_DIR/libs/s2geometry
 
 # Remove old downloads
-rm -rf $MAPLIBRE_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $QMLRUNNER_SRC_DIR $MIMIC_SRC_DIR $PICOTTS_SRC_DIR $S2GEOMETRY_SRC_DIR
+rm -rf $MAPLIBRE_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $QMLRUNNER_SRC_DIR $MIMIC_SRC_DIR $PICOTTS_SRC_DIR $S2GEOMETRY_SRC_DIR $ABSEIL_SRC_DIR
 
 # Download sources
 git clone -b qt-v2.0.1 ${CLONE_ARGS} https://github.com/maplibre/maplibre-gl-native.git $MAPLIBRE_GL_NATIVE_SRC_DIR
 git clone -b 2.1.1 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
 git clone -b 1.0.2 ${CLONE_ARGS} https://github.com/rinigus/qmlrunner.git $QMLRUNNER_SRC_DIR
-git clone -b 0.9.0+git2 ${CLONE_ARGS} https://github.com/rinigus/s2geometry.git $S2GEOMETRY_SRC_DIR
+git clone -b v0.11.1 ${CLONE_ARGS} https://github.com/google/s2geometry.git $S2GEOMETRY_SRC_DIR
+git clone -b 20240722.0 ${CLONE_ARGS} https://github.com/abseil/abseil-cpp.git $ABSEIL_SRC_DIR
 
 if [ "$ENABLE_MIMIC" == "1" ] ; then
 	wget -qO- https://github.com/MycroftAI/mimic1/archive/${MIMIC_VERSION}.tar.gz  | tar -xzv && mv mimic1-${MIMIC_VERSION} $MIMIC_SRC_DIR
@@ -35,3 +37,6 @@ fi
 # Apply patches
 cd $MAPLIBRE_GL_NATIVE_SRC_DIR
 git apply $ROOT_DIR/packaging/click/patches/maplibre-gl-native/*.patch
+
+cd $ABSEIL_SRC_DIR
+git apply $ROOT_DIR/packaging/click/patches/abseil/*.patch

--- a/packaging/click/slim-build.yaml
+++ b/packaging/click/slim-build.yaml
@@ -23,7 +23,6 @@ install_qml:
 - ${MAPBOX_GL_QML_LIB_INSTALL_DIR}/usr/lib/${ARCH_TRIPLET}/qt5/qml/MapboxMap
 install_lib:
 - ${MAPLIBRE_GL_NATIVE_LIB_INSTALL_DIR}/lib/libQMapLibreGL.so*
-- ${S2GEOMETRY_LIB_INSTALL_DIR}/lib/*.so*
 install_bin:
 - ${PICOTTS_LIB_INSTALL_DIR}/usr/bin/pico2wave
 install_root_data:
@@ -49,12 +48,16 @@ libraries:
     build_args:
     - -DCMAKE_CXX_STANDARD=14
 
+  abseil:
+    builder: cmake
+    build_args:
+    - -DABSL_ENABLE_INSTALL=ON
+
   s2geometry:
     builder: cmake
     build_args:
-    - -DBUILD_PYTHON=OFF
-    - -DBUILD_TESTING=OFF
-    - -DBUILD_SHARED_LIBS=ON
+    - -DBUILD_TESTS=OFF
+    - -DBUILD_SHARED_LIBS=OFF
     - -DBUILD_EXAMPLES=OFF
     dependencies_target:
     - swig


### PR DESCRIPTION
Switch to upstream s2geometry v0.11.1 due to #677 for click build and add transient abseil dependency.