### PR TITLE
languageIndex is -1 after created

### DIFF
--- a/qml/LanguageSelector.qml
+++ b/qml/LanguageSelector.qml
@@ -52,6 +52,7 @@ ComboBoxPL {
 
         index = model.indexOf(languages[index].name);
         comboBox.currentIndex = index;
+        languageIndex = index
     }
     onCurrentIndexChanged: {
         if (comboBox.currentIndex < 0) return;


### PR DESCRIPTION
Steps to reproduce:
- preferences
- testing
- test

Expected result:
Text to speech test is started

Current result:
```
Nov 29 10:05:53 ubuntu-phablet aa-exec[8098]: file:///opt/click.ubuntu.com/pure-maps-slim.jonnius/3.4.0/share/pure-maps-slim.jonnius/qml/PreferencesPage.qml:1012: TypeError: Cannot read property 'text' of undefined
```