### PR TITLE
show distance with digits when below 5km

### DIFF
--- a/src/navigator.cpp
+++ b/src/navigator.cpp
@@ -1024,7 +1024,7 @@ QString Navigator::distanceToStr_metric(double meters, bool condence) const
   if (meters > 1000)
     {
       unit = condence ? trans("km") : trans("kilometers");
-      return QString("%1 %2").arg(n2Str(meters/1000, 0)).arg(unit);
+      return QString("%1 %2").arg(n2Str(meters/1000, meters > 5000 ? 0 : -2)).arg(unit);
     }
   unit = condence ? trans("m") : trans("meters");
   return QString("%1 %2").arg(n2Str(meters, meters > 150 ? 2 : 1)).arg(unit);


### PR DESCRIPTION
Currently the remaining distance when navigating is show rounded to full kilometers when above 1000m e.g. 2km or 5km.

Although that might be fine when going by car, but for walking I consider this too unprecise. It does make a difference when you're walking if the distance is 1000m, 1500m or 2000m.

So with this PR I suggest to show two digits for the distance when below 5km. I think even when walking all numbers above are fine to be rounded.