### PR TITLE
bump clickable minimum version to lates stable release

### DIFF
--- a/packaging/click/full-build.yaml
+++ b/packaging/click/full-build.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 7.8.0
+clickable_minimum_required: 8
 
 scripts:
   prepare-deps: git submodule update --recursive --init && ENABLE_MIMIC=1 ${ROOT}/packaging/click/prepare-deps.sh

--- a/packaging/click/slim-build.yaml
+++ b/packaging/click/slim-build.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 7.8.0
+clickable_minimum_required: 8
 
 scripts:
   prepare-deps: git submodule update --recursive --init && ENABLE_MIMIC=0 ${ROOT}/packaging/click/prepare-deps.sh


### PR DESCRIPTION
This PR will bump the clickable minimum version to the latest stable release. Using no digits, as far as I know, results in the build using the main version 8 with the latest subversion available, rather than using a fixed number e.g. 8.2.0.

I hope I didn't miss any other place where this might be used or needs updating like some git actions.