### PR TITLE
Let click package target Ubuntu Touch 24.04

### DIFF
--- a/packaging/click/full-build.yaml
+++ b/packaging/click/full-build.yaml
@@ -3,7 +3,7 @@ clickable_minimum_required: 7.8.0
 scripts:
   prepare-deps: git submodule update --recursive --init && ENABLE_MIMIC=1 ${ROOT}/packaging/click/prepare-deps.sh
 
-framework: ubuntu-sdk-20.04
+framework: ubuntu-touch-24.04-1.x
 kill: pure-maps
 
 builder: cmake

--- a/packaging/click/full-build.yaml
+++ b/packaging/click/full-build.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 7.8.0
+clickable_minimum_required: 8.4.0
 
 scripts:
   prepare-deps: git submodule update --recursive --init && ENABLE_MIMIC=1 ${ROOT}/packaging/click/prepare-deps.sh

--- a/packaging/click/patches/maplibre-gl-native/add-some-missing-cstdint-inclusions-872-874.patch
+++ b/packaging/click/patches/maplibre-gl-native/add-some-missing-cstdint-inclusions-872-874.patch
@@ -1,0 +1,81 @@
+From 87025882ec733832d4314554c1d01efca9dbce0b Mon Sep 17 00:00:00 2001
+From: Fabian Vogt <fabian@ritter-vogt.de>
+Date: Fri, 3 Mar 2023 15:02:38 +0100
+Subject: [PATCH] Add some missing cstdint inclusions (#872) (#874)
+
+---
+ expression-test/expression_test_logger.hpp | 1 +
+ include/mbgl/i18n/number_format.hpp        | 1 +
+ include/mbgl/util/geometry.hpp             | 2 ++
+ include/mbgl/util/string.hpp               | 1 +
+ src/mbgl/programs/gl/shaders.hpp           | 1 +
+ vendor/eternal                             | 2 +-
+ 6 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/expression-test/expression_test_logger.hpp b/expression-test/expression_test_logger.hpp
+index 95b0697cb5b..ae03476fa3e 100644
+--- a/expression-test/expression_test_logger.hpp
++++ b/expression-test/expression_test_logger.hpp
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ 
+ #define ANSI_COLOR_RED        "\x1b[31m"
+diff --git a/include/mbgl/i18n/number_format.hpp b/include/mbgl/i18n/number_format.hpp
+index cb1e94c7bd7..dceddfe96b1 100644
+--- a/include/mbgl/i18n/number_format.hpp
++++ b/include/mbgl/i18n/number_format.hpp
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace mbgl {
+diff --git a/include/mbgl/util/geometry.hpp b/include/mbgl/util/geometry.hpp
+index c4fe52e87d9..5fc9c59e7f1 100644
+--- a/include/mbgl/util/geometry.hpp
++++ b/include/mbgl/util/geometry.hpp
+@@ -1,5 +1,7 @@
+ #pragma once
+ 
++#include <cstdint>
++
+ #include <mapbox/geometry/geometry.hpp>
+ #include <mapbox/geometry/point_arithmetic.hpp>
+ #include <mapbox/geometry/for_each_point.hpp>
+diff --git a/include/mbgl/util/string.hpp b/include/mbgl/util/string.hpp
+index df205b9072d..370b08afaf7 100644
+--- a/include/mbgl/util/string.hpp
++++ b/include/mbgl/util/string.hpp
+@@ -1,6 +1,7 @@
+ #pragma once
+ 
+ #include <string>
++#include <cstdint>
+ #include <cstdlib>
+ #include <type_traits>
+ #include <exception>
+diff --git a/src/mbgl/programs/gl/shaders.hpp b/src/mbgl/programs/gl/shaders.hpp
+index 46a87f4af88..25a1e6cb506 100644
+--- a/src/mbgl/programs/gl/shaders.hpp
++++ b/src/mbgl/programs/gl/shaders.hpp
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ 
+ namespace mbgl {
+diff --git a/vendor/eternal b/vendor/eternal
+index 42801e2a736..dd2f5b9ff38 160000
+--- a/vendor/eternal
++++ b/vendor/eternal
+@@ -1 +1 @@
+-Subproject commit 42801e2a736f362ae851b7962b4aa1d4f4b2d424
++Subproject commit dd2f5b9ff38fcd36b59efd9d289127fa73efc6cb
+-- 
+2.43.0
+

--- a/packaging/click/patches/maplibre-gl-native_eternal/missing-include.patch
+++ b/packaging/click/patches/maplibre-gl-native_eternal/missing-include.patch
@@ -1,0 +1,12 @@
+diff --git a/include/mapbox/eternal.hpp b/include/mapbox/eternal.hpp
+index 10c2f82..45dbbe6 100644
+--- a/include/mapbox/eternal.hpp
++++ b/include/mapbox/eternal.hpp
+@@ -1,6 +1,7 @@
+ #pragma once
+ 
+ #include <utility>
++#include <cstdint>
+ #include <functional>
+ 
+ // GCC 4.9 compatibility

--- a/packaging/click/patches/mimic/fix-compilation.patch
+++ b/packaging/click/patches/mimic/fix-compilation.patch
@@ -1,0 +1,25 @@
+unchanged:
+--- a/lang/cmu_indic_lang/cmu_indic_lang.h
++++ b/lang/cmu_indic_lang/cmu_indic_lang.h
+@@ -51,7 +51,7 @@ void cmu_indic_lang_init(cst_voice *v);
+ extern const cst_phoneset cmu_indic_phoneset;
+ extern const cst_cart cmu_indic_phrasing_cart; 
+ 
+-const cst_regex * const cst_rx_not_indic;
++extern const cst_regex * const cst_rx_not_indic;
+ 
+ #ifdef __cplusplus
+ } /* extern "C" */
+only in patch2:
+unchanged:
+--- a/src/hts/hts_engine_API/lib/HTS_model.c
++++ b/src/hts/hts_engine_API/lib/HTS_model.c
+@@ -698,7 +698,7 @@ static HTS_Boolean HTS_Model_load_pdf(HTS_Model * model, HTS_File * fp, size_t v
+    }
+    if (result == FALSE) {
+       model->npdf += 2;
+-      free(model->npdf);
++      HTS_free(model->npdf);
+       HTS_Model_initialize(model);
+       return FALSE;
+    }

--- a/packaging/click/prepare-deps.sh
+++ b/packaging/click/prepare-deps.sh
@@ -15,6 +15,7 @@ MIMIC_VERSION="1.3.0.1"
 PICOTTS_SRC_DIR=$ROOT_DIR/libs/picotts
 ABSEIL_SRC_DIR=$ROOT_DIR/libs/abseil
 S2GEOMETRY_SRC_DIR=$ROOT_DIR/libs/s2geometry
+PATCH_DIR=$ROOT_DIR/packaging/click/patches
 
 # Remove old downloads
 rm -rf $MAPLIBRE_GL_NATIVE_SRC_DIR $MAPBOX_GL_QML_SRC_DIR $QMLRUNNER_SRC_DIR $MIMIC_SRC_DIR $PICOTTS_SRC_DIR $S2GEOMETRY_SRC_DIR $ABSEIL_SRC_DIR
@@ -36,10 +37,13 @@ fi
 
 # Apply patches
 cd $MAPLIBRE_GL_NATIVE_SRC_DIR
-git apply $ROOT_DIR/packaging/click/patches/maplibre-gl-native/*.patch
+git apply $PATCH_DIR/maplibre-gl-native/*.patch
 
 cd $MAPLIBRE_GL_NATIVE_SRC_DIR/vendor/eternal
-git apply $ROOT_DIR/packaging/click/patches/maplibre-gl-native_eternal/*.patch
+git apply $PATCH_DIR/maplibre-gl-native_eternal/*.patch
 
 cd $ABSEIL_SRC_DIR
-git apply $ROOT_DIR/packaging/click/patches/abseil/*.patch
+git apply $PATCH_DIR/abseil/*.patch
+
+cd $MIMIC_SRC_DIR
+patch -p1 < $PATCH_DIR/mimic/fix-compilation.patch

--- a/packaging/click/prepare-deps.sh
+++ b/packaging/click/prepare-deps.sh
@@ -24,7 +24,7 @@ git clone -b qt-v2.0.1 ${CLONE_ARGS} https://github.com/maplibre/maplibre-gl-nat
 git clone -b 2.1.1 ${CLONE_ARGS} https://github.com/rinigus/mapbox-gl-qml.git $MAPBOX_GL_QML_SRC_DIR
 git clone -b 1.0.2 ${CLONE_ARGS} https://github.com/rinigus/qmlrunner.git $QMLRUNNER_SRC_DIR
 git clone -b v0.11.1 ${CLONE_ARGS} https://github.com/google/s2geometry.git $S2GEOMETRY_SRC_DIR
-git clone -b 20240722.0 ${CLONE_ARGS} https://github.com/abseil/abseil-cpp.git $ABSEIL_SRC_DIR
+git clone -b 20250127.1 ${CLONE_ARGS} https://github.com/abseil/abseil-cpp.git $ABSEIL_SRC_DIR
 
 if [ "$ENABLE_MIMIC" == "1" ] ; then
 	wget -qO- https://github.com/MycroftAI/mimic1/archive/${MIMIC_VERSION}.tar.gz  | tar -xzv && mv mimic1-${MIMIC_VERSION} $MIMIC_SRC_DIR

--- a/packaging/click/prepare-deps.sh
+++ b/packaging/click/prepare-deps.sh
@@ -38,5 +38,8 @@ fi
 cd $MAPLIBRE_GL_NATIVE_SRC_DIR
 git apply $ROOT_DIR/packaging/click/patches/maplibre-gl-native/*.patch
 
+cd $MAPLIBRE_GL_NATIVE_SRC_DIR/vendor/eternal
+git apply $ROOT_DIR/packaging/click/patches/maplibre-gl-native_eternal/*.patch
+
 cd $ABSEIL_SRC_DIR
 git apply $ROOT_DIR/packaging/click/patches/abseil/*.patch

--- a/packaging/click/pure-maps.apparmor
+++ b/packaging/click/pure-maps.apparmor
@@ -6,5 +6,5 @@
         "content_exchange",
         "networking"
     ],
-    "policy_version": 2404.1
+    "policy_version": "@APPARMOR_POLICY@"
 }

--- a/packaging/click/pure-maps.apparmor
+++ b/packaging/click/pure-maps.apparmor
@@ -6,5 +6,5 @@
         "content_exchange",
         "networking"
     ],
-    "policy_version": 20.04
+    "policy_version": 2404.1
 }

--- a/packaging/click/slim-build.yaml
+++ b/packaging/click/slim-build.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 8.3.1
+clickable_minimum_required: 8.4.0
 
 scripts:
   prepare-deps: git submodule update --recursive --init && ENABLE_MIMIC=0 ${ROOT}/packaging/click/prepare-deps.sh

--- a/packaging/click/slim-build.yaml
+++ b/packaging/click/slim-build.yaml
@@ -1,9 +1,9 @@
-clickable_minimum_required: 7.8.0
+clickable_minimum_required: 8.3.1
 
 scripts:
   prepare-deps: git submodule update --recursive --init && ENABLE_MIMIC=0 ${ROOT}/packaging/click/prepare-deps.sh
 
-framework: ubuntu-sdk-20.04
+framework: ubuntu-touch-24.04-1.x
 kill: pure-maps
 
 builder: cmake


### PR DESCRIPTION
The build config is made in a way that it should still be possible to target Ubuntu Touch 20.04 by setting the env var `CLICKABLE_FRAMEWORK` accordingly.