### PR TITLE
appdata: update appstream data so app appears in Flathub mobile collection

### DIFF
--- a/packaging/pure-maps.appdata.xml
+++ b/packaging/pure-maps.appdata.xml
@@ -19,6 +19,13 @@
  <url type="donation">https://rinigus.github.io/donate</url>
  <url type="translate">https://www.transifex.com/rinigus/pure-maps</url>
  <launchable type="desktop-id">io.github.rinigus.PureMaps.desktop</launchable>
+ <supports>
+  <control>touch</control>
+  <control>pointing</control>
+ </supports>
+ <requires>
+  <display_length compare="ge">360</display_length>
+ </requires>
  <provides>
   <binary>pure-maps</binary>
  </provides>


### PR DESCRIPTION
You can test this with `appstreamcli check-syscompat ./packaging/pure-maps.appdata.xml`

Before:
```
Chassis compatibility check for: */*/*/io.github.rinigus.PureMaps/*

Desktop:
 ✔ Compatible (100%)

Laptop:
 ✔ Compatible (100%)

Server:
 ✘ Incompatible

Tablet:
 ✘ Incompatible

Handset:
 ✘ Incompatible

```

After:
```bash
Chassis compatibility check for: */*/*/io.github.rinigus.PureMaps/*

Desktop:
 ✔ Compatible (100%)

Laptop:
 ✔ Compatible (100%)

Server:
 ✘ Incompatible

Tablet:
 ✔ Compatible (100%)

Handset:
 ✔ Compatible (100%)

```