### PR TITLE
docs: fix README successful typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Methods:
 * `Clear()` - stops navigation and removes current route
 
 * `Start() -> Boolean` - start navigation and returns `true` if
-  succesful. If already started or has no route defined, will return
+  successful. If already started or has no route defined, will return
   `false` to indicate failure.
 
 * `Stop()` - stop navigation if running.


### PR DESCRIPTION
## Summary
- Fixes one README spelling typo: `succesful` -> `successful` in the DBus navigation API description.

## Validation
- `rg -n -C 2 'succesful|successful|Start\(\) -> Boolean|start navigation' README.md`
- `git diff --check`

No runtime tests were run because this is a README-only spelling correction and does not change code, commands, generated output, configuration, or behavior.
