### PR TITLE
Set desktopId for Geoclue2 from QGuiApplication property

### DIFF
--- a/src/geoclue2/qgeopositioninfosource_geoclue2.cpp
+++ b/src/geoclue2/qgeopositioninfosource_geoclue2.cpp
@@ -47,6 +47,7 @@
 #include <QtCore/QScopedPointer>
 #include <QtCore/QTimer>
 #include <QtDBus/QDBusPendingCallWatcher>
+#include <QGuiApplication>
 
 // Auto-generated D-Bus files.
 #include "clientinterface.h"
@@ -346,12 +347,15 @@ bool PM::QGeoPositionInfoSourceGeoclue2::configureClient()
 
     auto desktopId = QString::fromUtf8(qgetenv("QT_GEOCLUE_APP_DESKTOP_ID"));
     if (desktopId.isEmpty())
+        desktopId = QGuiApplication::desktopFileName().replace(QRegularExpression("\\.desktop$"), "");
+    if (desktopId.isEmpty())
         desktopId = QCoreApplication::applicationName();
     if (desktopId.isEmpty()) {
         qCCritical(lcPositioningGeoclue2) << "Unable to configure the client "
                                              "due to the application desktop id "
                                              "is not set via QT_GEOCLUE_APP_DESKTOP_ID "
-                                             "envirorment variable or QCoreApplication::applicationName";
+                                             "environment variable or QGuiApplication::desktopFileName"
+                                             "or QCoreApplication::applicationName properties";
         setError(AccessError);
         return false;
     }


### PR DESCRIPTION
Geoclue authentication agents require a desktopId argument which needs to match an installed .desktop file for the application. Set the arg from QGuiApplication::desktopFileName property.

---

The original reasons for bundling the geoclue2 plugin seem to have been fixed in latest opensource Qt5 releases (at least in `qtlocation-opensource-src` in Debian, no idea where the upstream sources for this package are though), but the `desktopId` argument to geoclue agent is still wrong, so I suppose pure-maps needs this still. 

The Qt6 version of the Geoclue2 plugin sends the correct desktopId.